### PR TITLE
Sort references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![](https://github.com/elastic/crd-ref-docs/workflows/Build/badge.svg)
+
+
 CRD Reference Documentation Generator
 ======================================
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -73,19 +73,6 @@ func Process(config *config.Config) ([]types.GroupVersionDetails, error) {
 				typeDef.References = append(typeDef.References, rd)
 			}
 		}
-
-		// sort the references
-		sort.SliceStable(typeDef.References, func(i, j int) bool {
-			if typeDef.References[i].Name < typeDef.References[j].Name {
-				return true
-			}
-
-			if typeDef.References[i].Name == typeDef.References[j].Name {
-				return typeDef.References[i].Package < typeDef.References[j].Package
-			}
-
-			return false
-		})
 	}
 
 	// build the return array

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -73,6 +73,19 @@ func Process(config *config.Config) ([]types.GroupVersionDetails, error) {
 				typeDef.References = append(typeDef.References, rd)
 			}
 		}
+
+		// sort the references
+		sort.SliceStable(typeDef.References, func(i, j int) bool {
+			if typeDef.References[i].Name < typeDef.References[j].Name {
+				return true
+			}
+
+			if typeDef.References[i].Name == typeDef.References[j].Name {
+				return typeDef.References[i].Package < typeDef.References[j].Package
+			}
+
+			return false
+		})
 	}
 
 	// build the return array

--- a/templates/asciidoctor/type.tpl
+++ b/templates/asciidoctor/type.tpl
@@ -10,7 +10,7 @@
 {{ if $type.References -}}
 .Appears In:
 ****
-{{- range $type.References }}
+{{- range $type.SortedReferences }}
 - {{ asciidocRenderTypeLink . }}
 {{- end }}
 ****

--- a/types/types.go
+++ b/types/types.go
@@ -174,6 +174,26 @@ func (t *Type) IsAlias() bool {
 	return t.Kind == AliasKind
 }
 
+func (t *Type) SortedReferences() []*Type {
+	if t == nil || len(t.References) == 0 {
+		return nil
+	}
+
+	sort.Slice(t.References, func(i, j int) bool {
+		if t.References[i].Name < t.References[j].Name {
+			return true
+		}
+
+		if t.References[i].Name == t.References[j].Name {
+			return t.References[i].Package < t.References[j].Package
+		}
+
+		return false
+	})
+
+	return t.References
+}
+
 // Field describes a field in a struct.
 type Field struct {
 	Name     string


### PR DESCRIPTION
Sorts the references of a type so that the generated documentation remains stable between runs.