### PR TITLE
Do not ignore basic type comments

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -440,11 +440,6 @@ func mkType(pkg *loader.Package, t gotypes.Type) *types.Type {
 }
 
 func (p *processor) loadAliasType(typeDef *types.Type, pkg *loader.Package, underlying gotypes.Type, depth int) *types.Type {
-	if bt, ok := underlying.(*gotypes.Basic); ok {
-		typeDef.UnderlyingType = &types.Type{Name: bt.String(), Kind: types.BasicKind}
-		return typeDef
-	}
-
 	tPkg := pkg
 
 	// check whether this type is imported
@@ -464,6 +459,12 @@ func (p *processor) loadAliasType(typeDef *types.Type, pkg *loader.Package, unde
 	tInfo := p.parser.LookupType(tPkg, typeDef.Name)
 	if tInfo == nil {
 		zap.S().Warnw("Failed to find type", "name", typeDef.Name, "package", typeDef.Package)
+		return typeDef
+	}
+
+	if bt, ok := underlying.(*gotypes.Basic); ok {
+		typeDef.UnderlyingType = &types.Type{Name: bt.String(), Kind: types.BasicKind}
+		typeDef.Doc = tInfo.Doc
 		return typeDef
 	}
 

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -41,6 +41,8 @@ type GuestbookEntry struct {
 	Time metav1.Time `json:"time,omitempty"`
 	// Comment by guest
 	Comment string `json:"comment,omitempty"`
+	// Rating provided by the guest
+	Rating Rating `json:"rating,omitempty"`
 }
 
 // GuestbookStatus defines the observed state of Guestbook.
@@ -70,6 +72,9 @@ type GuestbookList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Guestbook `json:"items"`
 }
+
+// Rating is the rating provided by a guest.
+type Rating string
 
 func init() {
 	SchemeBuilder.Register(&Guestbook{}, &GuestbookList{})

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -56,13 +56,14 @@ GuestbookEntry defines an entry in a guest book.
 | *`name`* __string__ | Name of the guest
 | *`time`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#time-v1-meta[$$Time$$]__ | Time of entry
 | *`comment`* __string__ | Comment by guest
+| *`rating`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-rating[$$Rating$$]__ | Rating provided by the guest
 |===
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookheader"]
 ==== GuestbookHeader (string) 
 
-
+GuestbookHeaders are strings to include at the top of a page.
 
 .Appears In:
 ****
@@ -108,6 +109,18 @@ GuestbookSpec defines the desired state of Guestbook.
 | *`headers`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookheader[$$GuestbookHeader$$] array__ | Headers contains a list of header items to include in the page
 |===
 
+
+
+
+[id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-rating"]
+==== Rating (string) 
+
+Rating is the rating provided by a guest.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookentry[$$GuestbookEntry$$]
+****
 
 
 


### PR DESCRIPTION
Comments attached to basic type aliases were missing because the code returned too early from the loop.
 
Thanks to @hugoShaka for finding the problem and suggesting a fix.

Fixes #7 