### PR TITLE
Escape pipe characters in asciidoc descriptions

### DIFF
--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -83,6 +83,7 @@ func (adr *AsciidoctorRenderer) ToFuncMap() template.FuncMap {
 		"SafeID":             adr.SafeID,
 		"ShouldRenderType":   adr.ShouldRenderType,
 		"TypeID":             adr.TypeID,
+		"Escape":             adr.Escape,
 	}
 }
 
@@ -139,4 +140,16 @@ func (adr *AsciidoctorRenderer) RenderGVLink(gv types.GroupVersionDetails) strin
 
 func (adr *AsciidoctorRenderer) RenderAnchorID(id string) string {
 	return fmt.Sprintf("%s%s", asciidocAnchorPrefix, adr.SafeID(id))
+}
+
+func (adr *AsciidoctorRenderer) Escape(text string) string {
+	escaped := ""
+	for _, r := range text {
+		if r == '|' {
+			escaped += "\\|"
+		} else {
+			escaped += string(r)
+		}
+	}
+	return escaped
 }

--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -83,7 +83,7 @@ func (adr *AsciidoctorRenderer) ToFuncMap() template.FuncMap {
 		"SafeID":             adr.SafeID,
 		"ShouldRenderType":   adr.ShouldRenderType,
 		"TypeID":             adr.TypeID,
-		"Escape":             adr.Escape,
+		"RenderFieldDoc":     adr.RenderFieldDoc,
 	}
 }
 
@@ -142,14 +142,8 @@ func (adr *AsciidoctorRenderer) RenderAnchorID(id string) string {
 	return fmt.Sprintf("%s%s", asciidocAnchorPrefix, adr.SafeID(id))
 }
 
-func (adr *AsciidoctorRenderer) Escape(text string) string {
-	escaped := ""
-	for _, r := range text {
-		if r == '|' {
-			escaped += "\\|"
-		} else {
-			escaped += string(r)
-		}
-	}
-	return escaped
+func (adr *AsciidoctorRenderer) RenderFieldDoc(text string) string {
+	// escape the pipe character, which has special meaning for asciidoc as a way to format tables,
+	// so that including | in a comment does not result in wonky tables
+	return strings.ReplaceAll(text, "|", "\\|")
 }

--- a/templates/asciidoctor/type_members.tpl
+++ b/templates/asciidoctor/type_members.tpl
@@ -3,6 +3,6 @@
 {{- if eq $field.Name "metadata" -}}
 Refer to Kubernetes API documentation for fields of `metadata`.
 {{ else -}}
-{{ asciidocEscape $field.Doc }}
+{{ asciidocRenderFieldDoc $field.Doc }}
 {{- end -}}
 {{- end -}}

--- a/templates/asciidoctor/type_members.tpl
+++ b/templates/asciidoctor/type_members.tpl
@@ -3,6 +3,6 @@
 {{- if eq $field.Name "metadata" -}}
 Refer to Kubernetes API documentation for fields of `metadata`.
 {{ else -}}
-{{ $field.Doc }}
+{{ asciidocEscape $field.Doc }}
 {{- end -}}
 {{- end -}}

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -35,7 +35,7 @@ type GuestbookSpec struct {
 
 // GuestbookEntry defines an entry in a guest book.
 type GuestbookEntry struct {
-	// Name | of the guest
+	// Name of the guest (pipe | should be escaped)
 	Name string `json:"name,omitempty"`
 	// Time of entry
 	Time metav1.Time `json:"time,omitempty"`

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -35,7 +35,7 @@ type GuestbookSpec struct {
 
 // GuestbookEntry defines an entry in a guest book.
 type GuestbookEntry struct {
-	// Name of the guest
+	// Name | of the guest
 	Name string `json:"name,omitempty"`
 	// Time of entry
 	Time metav1.Time `json:"time,omitempty"`

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -53,7 +53,7 @@ GuestbookEntry defines an entry in a guest book.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | Name \| of the guest
+| *`name`* __string__ | Name of the guest (pipe \| should be escaped)
 | *`time`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta[$$Time$$]__ | Time of entry
 | *`comment`* __string__ | Comment by guest
 | *`rating`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-rating[$$Rating$$]__ | Rating provided by the guest

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -53,7 +53,7 @@ GuestbookEntry defines an entry in a guest book.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | Name of the guest
+| *`name`* __string__ | Name \| of the guest
 | *`time`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta[$$Time$$]__ | Time of entry
 | *`comment`* __string__ | Comment by guest
 | *`rating`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-rating[$$Rating$$]__ | Rating provided by the guest

--- a/test/expected.md
+++ b/test/expected.md
@@ -42,7 +42,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name of the guest |
+| `name` _string_ | Name | of the guest |
 | `time` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ | Time of entry |
 | `comment` _string_ | Comment by guest |
 | `rating` _[Rating](#rating)_ | Rating provided by the guest |

--- a/test/expected.md
+++ b/test/expected.md
@@ -42,7 +42,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name | of the guest |
+| `name` _string_ | Name of the guest (pipe | should be escaped) |
 | `time` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ | Time of entry |
 | `comment` _string_ | Comment by guest |
 | `rating` _[Rating](#rating)_ | Rating provided by the guest |


### PR DESCRIPTION
* Provides a function to escape the pipe character, which has special meaning for asciidoc as a way to format tables, so that including | in a comment does not result in wonky tables.
* Wrap type_members in the new escape function

This does not include:
* changes to the markdown renderer (since escaping could be flavor-specific. For example GFM would use `\|` but other flavors could use `&#124;`).
* Escaping other characters, although that could be added.

For context, my team uses crd-ref-docs, and it has worked great for the most part. However we want to describe an LDAP query with a pipe character in a comment, but this led to the API docs showing a table that didn't render correctly. See [here](https://github.com/vmware-tanzu/pinniped/blob/main/generated/1.20/README.adoc#k8s-api-go-pinniped-dev-generated-1-20-apis-supervisor-idp-v1alpha1-activedirectoryidentityproviderusersearch)