### PR TITLE
Fix array/slice/pointer type for custom types

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -360,40 +360,57 @@ func (p *processor) loadType(pkg *loader.Package, t gotypes.Type, depth int) *ty
 		return nil
 	}
 
-	if x, ok := p.types[types.Key(typeDef)]; ok {
-		return x
-	}
-
 	zap.S().Debugw("Load", "package", typeDef.Package, "name", typeDef.Name)
 
 	switch x := t.(type) {
-	case *gotypes.Basic:
-		typeDef.Kind = types.BasicKind
-		typeDef.Package = ""
-
 	case *gotypes.Pointer:
+		if y, ok := p.types[types.Key(typeDef)]; ok {
+			typeDef = y.Copy()
+			typeDef.UnderlyingType = y
+		} else {
+			typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
+		}
 		typeDef.Kind = types.PointerKind
-		typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
 		if typeDef.UnderlyingType != nil && typeDef.UnderlyingType.Kind == types.BasicKind {
 			typeDef.Package = ""
 		}
 		return typeDef
 
 	case *gotypes.Slice:
+		if y, ok := p.types[types.Key(typeDef)]; ok {
+			typeDef = y.Copy()
+			typeDef.UnderlyingType = y
+		} else {
+			typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
+		}
 		typeDef.Kind = types.SliceKind
-		typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
 		if typeDef.UnderlyingType != nil && typeDef.UnderlyingType.Kind == types.BasicKind {
 			typeDef.Package = ""
 		}
 		return typeDef
 
 	case *gotypes.Array:
+		if y, ok := p.types[types.Key(typeDef)]; ok {
+			typeDef = y.Copy()
+			typeDef.UnderlyingType = y
+		} else {
+			typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
+		}
 		typeDef.Kind = types.ArrayKind
-		typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
 		if typeDef.UnderlyingType != nil && typeDef.UnderlyingType.Kind == types.BasicKind {
 			typeDef.Package = ""
 		}
 		return typeDef
+	}
+
+	if x, ok := p.types[types.Key(typeDef)]; ok {
+		return x
+	}
+
+	switch x := t.(type) {
+	case *gotypes.Basic:
+		typeDef.Kind = types.BasicKind
+		typeDef.Package = ""
 
 	case *gotypes.Map:
 		typeDef.Kind = types.MapKind

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -86,7 +86,7 @@ GuestbookList contains a list of Guestbook.
 | *`kind`* __string__ | `GuestbookList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbook[$$Guestbook$$]__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbook[$$Guestbook$$] array__ | 
 |===
 
 

--- a/test/expected.md
+++ b/test/expected.md
@@ -72,7 +72,7 @@ GuestbookList contains a list of Guestbook.
 | `apiVersion` _string_ | `webapp.test.k8s.elastic.co/v1`
 | `kind` _string_ | `GuestbookList`
 | `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `items` _[Guestbook](#guestbook)_ |  |
+| `items` _[Guestbook](#guestbook) array_ |  |
 
 
 #### GuestbookSpec

--- a/types/types.go
+++ b/types/types.go
@@ -111,6 +111,22 @@ type Type struct {
 	References     []*Type                  `json:"-"`              // other types that refer to this type
 }
 
+func (t *Type) Copy() *Type {
+	return &Type{
+		Name:           t.Name,
+		Package:        t.Package,
+		Doc:            t.Doc,
+		GVK:            t.GVK,
+		Kind:           t.Kind,
+		Imported:       t.Imported,
+		UnderlyingType: t.UnderlyingType,
+		KeyType:        t.KeyType,
+		ValueType:      t.ValueType,
+		Fields:         t.Fields,
+		References:     t.References,
+	}
+}
+
 func (t *Type) IsBasic() bool {
 	switch t.Kind {
 	case BasicKind:


### PR DESCRIPTION
Closes https://github.com/elastic/crd-ref-docs/issues/20

Checks if the type is array, slice, or pointer, even though the type name is already known.
Is therefore able to return `[]Foo`, instead of simply returning `Foo`, when `Foo` is already known.