### PR TITLE
Wire field markers and tags to types.Field

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -318,6 +318,8 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 			Name:     f.Name,
 			Doc:      f.Doc,
 			Embedded: f.Name == "",
+			Markers:  f.Markers,
+			Tag:      f.Tag,
 		}
 
 		if tagVal, ok := f.Tag.Lookup("json"); ok {

--- a/types/types.go
+++ b/types/types.go
@@ -19,11 +19,13 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 
 // Kind describes the kind of the type (alias, array, etc.)
@@ -270,6 +272,8 @@ type Field struct {
 	Embedded bool
 	Inlined  bool
 	Doc      string
+	Markers  markers.MarkerValues
+	Tag      reflect.StructTag
 	Type     *Type
 }
 


### PR DESCRIPTION
This allows users to use field markers and tags in their own templates