### PR TITLE
chore: update go mod version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/crd-ref-docs
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION
Missing from https://github.com/elastic/crd-ref-docs/pull/42 ?