### PR TITLE
fix: parse standalone types correctly

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -283,7 +283,7 @@ func (p *processor) processType(pkg *loader.Package, info *markers.TypeInfo, dep
 		return p.processStructFields(typeDef, pkg, info, depth)
 	}
 
-	t := pkg.TypesInfo.TypeOf(info.RawSpec.Type)
+	t := pkg.TypesInfo.TypeOf(info.RawSpec.Name)
 	if t == nil {
 		zap.S().Warnw("Failed to determine AST type", "package", pkg.PkgPath, "type", info.Name)
 		typeDef.Kind = types.UnknownKind

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -48,6 +48,12 @@ type EmbeddedX struct {
 	X string `json:"x,omitempty"`
 }
 
+// NOTE: Rating is placed here to ensure that it is parsed as a standalone type
+// before it is parsed as a struct field.
+
+// Rating is the rating provided by a guest.
+type Rating string
+
 // GuestbookSpec defines the desired state of Guestbook.
 type GuestbookSpec struct {
 	// Page indicates the page number
@@ -101,9 +107,6 @@ type GuestbookList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Guestbook `json:"items"`
 }
-
-// Rating is the rating provided by a guest.
-type Rating string
 
 func init() {
 	SchemeBuilder.Register(&Guestbook{}, &GuestbookList{})


### PR DESCRIPTION
Standalone types was previously only parsed correctly if part of a struct, and parsed as a struct field.

Without the processor change, moving `Rating` to the top causes the following diff:

```
ERROR: outputs differ

| *`rating`* __xref:{anchor_prefix}-github-com-elastic-crd-re | | *`rating`* __Rating__ | Rating provided by the guest
                                                              <
                                                              <
                                                              <
[id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-r <
==== Rating (string)                                          <
                                                              <
Rating is the rating provided by a guest.                     <
                                                              <
.Appears In:                                                  <
****                                                          <
- xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1 <
****                                                          <
```