### PR TITLE
feat: improve parsing

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -87,7 +87,7 @@ func Process(config *config.Config) ([]types.GroupVersionDetails, error) {
 
 		details.Types = make(types.TypeMap)
 		for name, t := range gvi.types {
-			key := types.Key(t)
+			key := types.Identifier(t)
 
 			if p.shouldIgnoreType(key) {
 				zap.S().Debugw("Skipping excluded type", "type", name)
@@ -193,10 +193,9 @@ func (p *processor) findAPITypes(directory string) error {
 			key := fmt.Sprintf("%s.%s", pkg.PkgPath, info.Name)
 			typeDef, ok := p.types[key]
 			if !ok {
-				typeDef = p.processType(pkg, info, 0)
+				typeDef = p.processType(pkg, nil, pkg.TypesInfo.TypeOf(info.RawSpec.Name), 0)
 			}
 
-			p.types[key] = typeDef
 			if typeDef != nil && typeDef.Kind != types.BasicKind {
 				gvInfo.types[info.Name] = typeDef
 			}
@@ -265,47 +264,116 @@ func (p *processor) extractPkgDocumentation(pkg *loader.Package) string {
 	return strings.Join(pkgComments, "\n")
 }
 
-func (p *processor) processType(pkg *loader.Package, info *markers.TypeInfo, depth int) *types.Type {
-	typeDef := &types.Type{
-		Name:    info.Name,
-		Package: pkg.PkgPath,
-		Doc:     info.Doc,
+func (p *processor) processType(pkg *loader.Package, parentType *types.Type, t gotypes.Type, depth int) *types.Type {
+	typeDef := mkType(pkg, t)
+
+	if processed, ok := p.types[typeDef.UID]; ok {
+		return processed
 	}
 
-	if p.useRawDocstring && info.RawDecl != nil {
-		// use raw docstring to support multi-line and indent preservation
-		typeDef.Doc = strings.TrimSuffix(info.RawDecl.Doc.Text(), "\n")
+	info := p.parser.LookupType(pkg, typeDef.Name)
+	if info != nil {
+		typeDef.Doc = info.Doc
+
+		if p.useRawDocstring && info.RawDecl != nil {
+			// use raw docstring to support multi-line and indent preservation
+			typeDef.Doc = strings.TrimSuffix(info.RawDecl.Doc.Text(), "\n")
+		}
 	}
 
-	// if the field list is non-empty, this is a struct
-	if len(info.Fields) > 0 {
-		typeDef.Kind = types.StructKind
-		return p.processStructFields(typeDef, pkg, info, depth)
-	}
-
-	t := pkg.TypesInfo.TypeOf(info.RawSpec.Name)
-	if t == nil {
-		zap.S().Warnw("Failed to determine AST type", "package", pkg.PkgPath, "type", info.Name)
+	if depth > p.maxDepth {
+		zap.S().Debugw("Not loading type due to reaching max recursion depth", "type", t.String())
 		typeDef.Kind = types.UnknownKind
 		return typeDef
 	}
 
-	tmpType := p.loadType(pkg, t, depth)
-	if tmpType == nil {
+	zap.S().Debugw("Load", "package", typeDef.Package, "name", typeDef.Name)
+
+	switch t := t.(type) {
+	case nil:
 		typeDef.Kind = types.UnknownKind
-		return typeDef
+		zap.S().Warnw("Failed to determine AST type", "package", pkg.PkgPath, "type", t.String())
+
+	case *gotypes.Named:
+		// Import the type's package if not within current package
+		if typeDef.Package != pkg.PkgPath {
+			imports := pkg.Imports()
+			importPkg, ok := imports[typeDef.Package]
+			if !ok {
+				zap.S().Warnw("Imported type cannot be found", "name", typeDef.Name, "package", typeDef.Package)
+				return typeDef
+			}
+			p.parser.NeedPackage(importPkg)
+			pkg = importPkg
+		}
+
+		typeDef.Kind = types.AliasKind
+		underlying := t.Underlying()
+		info := p.parser.LookupType(pkg, typeDef.Name)
+		if info != nil {
+			underlying = pkg.TypesInfo.TypeOf(info.RawSpec.Type)
+		}
+		typeDef.UnderlyingType = p.processType(pkg, typeDef, underlying, depth+1)
+		p.addReference(typeDef, typeDef.UnderlyingType)
+
+	case *gotypes.Struct:
+		if parentType != nil {
+			// Rather than the parent being a Named type with a "raw" Struct as
+			// UnderlyingType, convert the parent to a Struct type.
+			parentType.Kind = types.StructKind
+			if info := p.parser.LookupType(pkg, parentType.Name); info != nil {
+				p.processStructFields(parentType, pkg, info, depth)
+			}
+			// Abort processing type and return nil as UnderlyingType of parent.
+			return nil
+		} else {
+			zap.S().Warnw("Anonymous structs are not supported", "package", pkg.PkgPath, "type", t.String())
+			typeDef.Name = ""
+			typeDef.Package = ""
+			typeDef.Kind = types.UnsupportedKind
+		}
+
+	case *gotypes.Pointer:
+		typeDef.Kind = types.PointerKind
+		typeDef.UnderlyingType = p.processType(pkg, typeDef, t.Elem(), depth+1)
+		if typeDef.UnderlyingType != nil {
+			typeDef.Package = typeDef.UnderlyingType.Package
+		}
+
+	case *gotypes.Slice:
+		typeDef.Kind = types.SliceKind
+		typeDef.UnderlyingType = p.processType(pkg, typeDef, t.Elem(), depth+1)
+		if typeDef.UnderlyingType != nil {
+			typeDef.Package = typeDef.UnderlyingType.Package
+		}
+
+	case *gotypes.Map:
+		typeDef.Kind = types.MapKind
+		typeDef.KeyType = p.processType(pkg, typeDef, t.Key(), depth+1)
+		typeDef.ValueType = p.processType(pkg, typeDef, t.Elem(), depth+1)
+		if typeDef.ValueType != nil {
+			typeDef.Package = typeDef.ValueType.Package
+		}
+
+	case *gotypes.Basic:
+		typeDef.Kind = types.BasicKind
+		typeDef.Package = ""
+
+	case *gotypes.Interface:
+		typeDef.Kind = types.InterfaceKind
+
+	default:
+		typeDef.Kind = types.UnsupportedKind
 	}
 
-	tmpType.Name = typeDef.Name
-	tmpType.Package = typeDef.Package
-	tmpType.Doc = typeDef.Doc
-	return tmpType
+	p.types[typeDef.UID] = typeDef
+	return typeDef
 }
 
-func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Package, info *markers.TypeInfo, depth int) *types.Type {
+func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Package, info *markers.TypeInfo, depth int) {
 	logger := zap.S().With("package", pkg.PkgPath, "type", parentType.String())
 	logger.Debugw("Processing struct fields")
-	parentTypeKey := types.Key(parentType)
+	parentTypeKey := types.Identifier(parentType)
 
 	for _, f := range info.Fields {
 		t := pkg.TypesInfo.TypeOf(f.RawField.Type)
@@ -328,10 +396,13 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 		}
 
 		logger.Debugw("Loading field type", "field", fieldDef.Name)
-		if fieldDef.Type = p.loadType(pkg, t, depth); fieldDef.Type == nil {
+		if fieldDef.Type = p.processType(pkg, nil, t, depth); fieldDef.Type == nil {
 			logger.Debugw("Failed to load type for field", "field", f.Name, "type", t.String())
 			continue
 		}
+
+		// Keep old behaviour, where struct fields are never regarded as imported
+		fieldDef.Type.Imported = false
 
 		if fieldDef.Embedded {
 			fieldDef.Inlined = fieldDef.Name == ""
@@ -346,97 +417,8 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 		}
 
 		parentType.Fields = append(parentType.Fields, fieldDef)
-
-		// add to references map
 		p.addReference(parentType, fieldDef.Type)
 	}
-
-	return parentType
-}
-
-func (p *processor) loadType(pkg *loader.Package, t gotypes.Type, depth int) *types.Type {
-	if depth > p.maxDepth {
-		zap.S().Debugw("Not loading type due to reaching max recursion depth", "type", t.String())
-		return nil
-	}
-
-	typeDef := mkType(pkg, t)
-
-	zap.S().Debugw("Load", "package", typeDef.Package, "name", typeDef.Name)
-
-	switch x := t.(type) {
-	case *gotypes.Pointer:
-		if y, ok := p.types[types.Key(typeDef)]; ok {
-			typeDef = y.Copy()
-			typeDef.UnderlyingType = y
-		} else {
-			typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
-		}
-		typeDef.Kind = types.PointerKind
-		if typeDef.UnderlyingType != nil && typeDef.UnderlyingType.Kind == types.BasicKind {
-			typeDef.Package = ""
-		}
-		return typeDef
-
-	case *gotypes.Slice:
-		if y, ok := p.types[types.Key(typeDef)]; ok {
-			typeDef = y.Copy()
-			typeDef.UnderlyingType = y
-		} else {
-			typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
-		}
-		typeDef.Kind = types.SliceKind
-		if typeDef.UnderlyingType != nil && typeDef.UnderlyingType.Kind == types.BasicKind {
-			typeDef.Package = ""
-		}
-		return typeDef
-
-	case *gotypes.Array:
-		if y, ok := p.types[types.Key(typeDef)]; ok {
-			typeDef = y.Copy()
-			typeDef.UnderlyingType = y
-		} else {
-			typeDef.UnderlyingType = p.loadType(pkg, x.Elem(), depth+1)
-		}
-		typeDef.Kind = types.ArrayKind
-		if typeDef.UnderlyingType != nil && typeDef.UnderlyingType.Kind == types.BasicKind {
-			typeDef.Package = ""
-		}
-		return typeDef
-	}
-
-	if x, ok := p.types[types.Key(typeDef)]; ok {
-		return x
-	}
-
-	switch x := t.(type) {
-	case *gotypes.Basic:
-		typeDef.Kind = types.BasicKind
-		typeDef.Package = ""
-
-	case *gotypes.Map:
-		typeDef.Kind = types.MapKind
-		typeDef.KeyType = p.loadType(pkg, x.Key(), depth+1)
-		typeDef.ValueType = p.loadType(pkg, x.Elem(), depth+1)
-
-	case *gotypes.Named:
-		typeDef.Kind = types.AliasKind
-		typeDef = p.loadAliasType(typeDef, pkg, x.Underlying(), depth)
-
-	case *gotypes.Interface:
-		if x.Empty() {
-			typeDef.Kind = types.InterfaceKind
-		} else {
-			return nil
-		}
-
-	default:
-		return nil
-	}
-
-	p.types[types.Key(typeDef)] = typeDef
-
-	return typeDef
 }
 
 func mkType(pkg *loader.Package, t gotypes.Type) *types.Type {
@@ -444,12 +426,15 @@ func mkType(pkg *loader.Package, t gotypes.Type) *types.Type {
 	cleanTypeName := strings.TrimLeft(gotypes.TypeString(t, qualifier), "*[]")
 
 	typeDef := &types.Type{
+		UID:     t.String(),
 		Name:    cleanTypeName,
 		Package: pkg.PkgPath,
 	}
 
-	// is this is an imported type?
-	if dotPos := strings.LastIndexByte(cleanTypeName, '.'); dotPos >= 0 {
+	// Check if the type is imported
+	rawType := strings.HasPrefix(cleanTypeName, "struct{") || strings.HasPrefix(cleanTypeName, "interface{")
+	dotPos := strings.LastIndexByte(cleanTypeName, '.')
+	if !rawType && dotPos >= 0 {
 		typeDef.Name = cleanTypeName[dotPos+1:]
 		typeDef.Package = cleanTypeName[:dotPos]
 		typeDef.Imported = true
@@ -458,76 +443,31 @@ func mkType(pkg *loader.Package, t gotypes.Type) *types.Type {
 	return typeDef
 }
 
-func (p *processor) loadAliasType(typeDef *types.Type, pkg *loader.Package, underlying gotypes.Type, depth int) *types.Type {
-	tPkg := pkg
-
-	// check whether this type is imported
-	if typeDef.Package != pkg.PkgPath {
-		imports := pkg.Imports()
-		importPkg, ok := imports[typeDef.Package]
-		if !ok {
-			zap.S().Warnw("Imported type cannot be found", "name", typeDef.Name, "package", typeDef.Package)
-			return typeDef
-		}
-
-		p.parser.NeedPackage(importPkg)
-		tPkg = importPkg
-	}
-
-	// find the type from the parser
-	tInfo := p.parser.LookupType(tPkg, typeDef.Name)
-	if tInfo == nil {
-		zap.S().Warnw("Failed to find type", "name", typeDef.Name, "package", typeDef.Package)
-		return typeDef
-	}
-
-	if bt, ok := underlying.(*gotypes.Basic); ok {
-		typeDef.UnderlyingType = &types.Type{Name: bt.String(), Kind: types.BasicKind}
-		typeDef.Doc = tInfo.Doc
-		return typeDef
-	}
-
-	return p.processType(tPkg, tInfo, depth+1)
-}
-
 // Every child that has a reference to 'originalType', will also get a reference to 'additionalType'.
 func (p *processor) propagateReference(originalType *types.Type, additionalType *types.Type) {
-	originalTypeKey := types.Key(originalType)
-	additionalTypeKey := types.Key(additionalType)
-
 	for _, parentRefs := range p.references {
-		if _, ok := parentRefs[originalTypeKey]; ok {
-			parentRefs[additionalTypeKey] = struct{}{}
+		if _, ok := parentRefs[originalType.UID]; ok {
+			parentRefs[additionalType.UID] = struct{}{}
 		}
 	}
 }
 
 func (p *processor) addReference(parent *types.Type, child *types.Type) {
-	if child == nil || child.Kind == types.BasicKind {
+	if child == nil {
 		return
 	}
 
-	addRef := func(t *types.Type) {
-		if t == nil || t.Kind == types.BasicKind {
-			return
-		}
-
-		parentTypeKey := types.Key(parent)
-		childTypeKey := types.Key(t)
-		if p.references[childTypeKey] == nil {
-			p.references[childTypeKey] = make(map[string]struct{})
-		}
-		p.references[childTypeKey][parentTypeKey] = struct{}{}
-	}
-
 	switch child.Kind {
-	case types.AliasKind, types.StructKind:
-		addRef(child)
-	case types.ArrayKind, types.SliceKind, types.PointerKind:
-		addRef(child.UnderlyingType)
+	case types.SliceKind, types.PointerKind:
+		p.addReference(parent, child.UnderlyingType)
 	case types.MapKind:
-		addRef(child.KeyType)
-		addRef(child.ValueType)
+		p.addReference(parent, child.KeyType)
+		p.addReference(parent, child.ValueType)
+	case types.AliasKind, types.StructKind:
+		if p.references[child.UID] == nil {
+			p.references[child.UID] = make(map[string]struct{})
+		}
+		p.references[child.UID][parent.UID] = struct{}{}
 	}
 }
 

--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -101,7 +101,7 @@ func (adr *AsciidoctorRenderer) RenderType(t *types.Type) string {
 		sb.WriteString(", values:")
 		sb.WriteString(adr.RenderTypeLink(t.ValueType))
 		sb.WriteString(")")
-	case types.ArrayKind, types.SliceKind:
+	case types.SliceKind:
 		sb.WriteString(adr.RenderTypeLink(t.UnderlyingType))
 		sb.WriteString(" array")
 	default:

--- a/renderer/functions.go
+++ b/renderer/functions.go
@@ -58,7 +58,7 @@ func NewFunctions(conf *config.Config) (*Functions, error) {
 }
 
 func (f *Functions) TypeID(t *types.Type) string {
-	return f.SafeID(types.Key(t))
+	return f.SafeID(types.Identifier(t))
 }
 
 func (f *Functions) GroupVersionID(gv types.GroupVersionDetails) string {
@@ -95,7 +95,7 @@ func (f *Functions) SimplifiedTypeName(t *types.Type) string {
 		return f.BasicTypeName(t.Name)
 	case types.PointerKind:
 		return f.BasicTypeName(t.UnderlyingType.Name)
-	case types.ArrayKind, types.SliceKind:
+	case types.SliceKind:
 		return fmt.Sprintf("%s array", f.BasicTypeName(t.UnderlyingType.Name))
 	case types.MapKind:
 		return "object"

--- a/renderer/markdown.go
+++ b/renderer/markdown.go
@@ -95,7 +95,7 @@ func (m *MarkdownRenderer) RenderType(t *types.Type) string {
 		sb.WriteString(", values:")
 		sb.WriteString(m.RenderTypeLink(t.ValueType))
 		sb.WriteString(")")
-	case types.ArrayKind, types.SliceKind:
+	case types.SliceKind:
 		sb.WriteString(m.RenderTypeLink(t.UnderlyingType))
 		sb.WriteString(" array")
 	default:

--- a/templates/asciidoctor/type.tpl
+++ b/templates/asciidoctor/type.tpl
@@ -3,7 +3,9 @@
 {{- if asciidocShouldRenderType $type -}}
 
 [id="{{ asciidocTypeID $type | asciidocRenderAnchorID }}"]
-==== {{ $type.Name  }} {{ if $type.IsAlias }}({{ asciidocRenderTypeLink $type.UnderlyingType  }}) {{ end }}
+==== {{ $type.Name  }}
+
+{{ if $type.IsAlias }}_Underlying type:_ _{{ asciidocRenderTypeLink $type.UnderlyingType  }}_{{ end }}
 
 {{ $type.Doc }}
 

--- a/templates/markdown/type.tpl
+++ b/templates/markdown/type.tpl
@@ -4,7 +4,7 @@
 
 #### {{ $type.Name }}
 
-{{ if $type.IsAlias }}_Underlying type:_ `{{ markdownRenderTypeLink $type.UnderlyingType  }}`{{ end }}
+{{ if $type.IsAlias }}_Underlying type:_ _{{ markdownRenderTypeLink $type.UnderlyingType  }}_{{ end }}
 
 {{ $type.Doc }}
 

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -51,6 +51,15 @@ type EmbeddedX struct {
 	X string `json:"x,omitempty"`
 }
 
+// Underlying tests that Underlying1's underlying type is Underlying2 instead of string.
+// +kubebuilder:object:root=true
+type Underlying struct {
+	A Underlying1 `json:"a,omitempty"`
+}
+
+type Underlying1 Underlying2
+type Underlying2 string
+
 // NOTE: Rating is placed here to ensure that it is parsed as a standalone type
 // before it is parsed as a struct field.
 

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -57,7 +57,10 @@ type Underlying struct {
 	A Underlying1 `json:"a,omitempty"`
 }
 
+// Underlying1 has an underlying type with an underlying type
 type Underlying1 Underlying2
+
+// Underlying2 is a string alias
 type Underlying2 string
 
 // NOTE: Rating is placed here to ensure that it is parsed as a standalone type

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -190,7 +190,7 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying1"]
 ==== Underlying1 (xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying2[$$Underlying2$$]) 
 
-
+Underlying1 has an underlying type with an underlying type
 
 .Appears In:
 ****
@@ -202,7 +202,7 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying2"]
 ==== Underlying2 (string) 
 
-
+Underlying2 is a string alias
 
 .Appears In:
 ****

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -188,7 +188,7 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying1"]
-==== Underlying1 (string) 
+==== Underlying1 (xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying2[$$Underlying2$$]) 
 
 
 
@@ -198,6 +198,16 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 ****
 
 
+
+[id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying2"]
+==== Underlying2 (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying1[$$Underlying1$$]
+****
 
 
 

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -17,6 +17,7 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 - xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-embedded[$$Embedded$$]
 - xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbook[$$Guestbook$$]
 - xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbooklist[$$GuestbookList$$]
+- xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying[$$Underlying$$]
 
 
 
@@ -167,6 +168,36 @@ Rating is the rating provided by a guest.
 ****
 - xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookentry[$$GuestbookEntry$$]
 ****
+
+
+
+[id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying"]
+==== Underlying 
+
+Underlying tests that Underlying1's underlying type is Underlying2 instead of string.
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `webapp.test.k8s.elastic.co/v1`
+| *`kind`* __string__ | `Underlying`
+| *`a`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying1[$$Underlying1$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying1"]
+==== Underlying1 (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying[$$Underlying$$]
+****
+
+
 
 
 

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -22,7 +22,9 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-embedded"]
-==== Embedded 
+==== Embedded
+
+
 
 
 
@@ -45,7 +47,9 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-embeddedx"]
-==== EmbeddedX 
+==== EmbeddedX
+
+
 
 
 
@@ -66,7 +70,9 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbook"]
-==== Guestbook 
+==== Guestbook
+
+
 
 Guestbook is the Schema for the guestbooks API.
 
@@ -87,7 +93,9 @@ Guestbook is the Schema for the guestbooks API.
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookentry"]
-==== GuestbookEntry 
+==== GuestbookEntry
+
+
 
 GuestbookEntry defines an entry in a guest book.
 
@@ -107,7 +115,9 @@ GuestbookEntry defines an entry in a guest book.
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookheader"]
-==== GuestbookHeader (string) 
+==== GuestbookHeader
+
+_Underlying type:_ _string_
 
 GuestbookHeaders are strings to include at the top of a page.
 
@@ -119,7 +129,9 @@ GuestbookHeaders are strings to include at the top of a page.
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbooklist"]
-==== GuestbookList 
+==== GuestbookList
+
+
 
 GuestbookList contains a list of Guestbook.
 
@@ -137,7 +149,9 @@ GuestbookList contains a list of Guestbook.
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookspec"]
-==== GuestbookSpec 
+==== GuestbookSpec
+
+
 
 GuestbookSpec defines the desired state of Guestbook.
 
@@ -160,7 +174,9 @@ GuestbookSpec defines the desired state of Guestbook.
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-rating"]
-==== Rating (string) 
+==== Rating
+
+_Underlying type:_ _string_
 
 Rating is the rating provided by a guest.
 
@@ -172,7 +188,9 @@ Rating is the rating provided by a guest.
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying"]
-==== Underlying 
+==== Underlying
+
+
 
 Underlying tests that Underlying1's underlying type is Underlying2 instead of string.
 
@@ -188,7 +206,9 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying1"]
-==== Underlying1 (xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying2[$$Underlying2$$]) 
+==== Underlying1
+
+_Underlying type:_ _xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying2[$$Underlying2$$]_
 
 Underlying1 has an underlying type with an underlying type
 
@@ -200,7 +220,9 @@ Underlying1 has an underlying type with an underlying type
 
 
 [id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-underlying2"]
-==== Underlying2 (string) 
+==== Underlying2
+
+_Underlying type:_ _string_
 
 Underlying2 is a string alias
 

--- a/test/expected.md
+++ b/test/expected.md
@@ -12,6 +12,7 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 - [Embedded](#embedded)
 - [Guestbook](#guestbook)
 - [GuestbookList](#guestbooklist)
+- [Underlying](#underlying)
 
 
 
@@ -143,6 +144,34 @@ Rating is the rating provided by a guest.
 
 _Appears in:_
 - [GuestbookEntry](#guestbookentry)
+
+
+
+#### Underlying
+
+
+
+Underlying tests that Underlying1's underlying type is Underlying2 instead of string.
+
+
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `webapp.test.k8s.elastic.co/v1`
+| `kind` _string_ | `Underlying`
+| `a` _[Underlying1](#underlying1)_ |  |
+
+
+#### Underlying1
+
+_Underlying type:_ `string`
+
+
+
+_Appears in:_
+- [Underlying](#underlying)
+
+
 
 
 

--- a/test/expected.md
+++ b/test/expected.md
@@ -166,7 +166,7 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 
 _Underlying type:_ `[Underlying2](#underlying2)`
 
-
+Underlying1 has an underlying type with an underlying type
 
 _Appears in:_
 - [Underlying](#underlying)
@@ -177,7 +177,7 @@ _Appears in:_
 
 _Underlying type:_ `string`
 
-
+Underlying2 is a string alias
 
 _Appears in:_
 - [Underlying1](#underlying1)

--- a/test/expected.md
+++ b/test/expected.md
@@ -164,7 +164,7 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 
 #### Underlying1
 
-_Underlying type:_ `string`
+_Underlying type:_ `[Underlying2](#underlying2)`
 
 
 
@@ -172,6 +172,15 @@ _Appears in:_
 - [Underlying](#underlying)
 
 
+
+#### Underlying2
+
+_Underlying type:_ `string`
+
+
+
+_Appears in:_
+- [Underlying1](#underlying1)
 
 
 

--- a/test/expected.md
+++ b/test/expected.md
@@ -91,7 +91,7 @@ _Appears in:_
 
 #### GuestbookHeader
 
-_Underlying type:_ `string`
+_Underlying type:_ _string_
 
 GuestbookHeaders are strings to include at the top of a page.
 
@@ -138,7 +138,7 @@ _Appears in:_
 
 #### Rating
 
-_Underlying type:_ `string`
+_Underlying type:_ _string_
 
 Rating is the rating provided by a guest.
 
@@ -164,7 +164,7 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 
 #### Underlying1
 
-_Underlying type:_ `[Underlying2](#underlying2)`
+_Underlying type:_ _[Underlying2](#underlying2)_
 
 Underlying1 has an underlying type with an underlying type
 
@@ -175,7 +175,7 @@ _Appears in:_
 
 #### Underlying2
 
-_Underlying type:_ `string`
+_Underlying type:_ _string_
 
 Underlying2 is a string alias
 


### PR DESCRIPTION
Simplifies a lot of the complexity of having separate `processType`, `loadType` and `loadAliasType`.

Removes ArrayKind, as it is not supported by controller-gen.

Also ensures correct parsing of `A` in the example below, making `A.UnderlyingType` equal `B` instead of `string`. This will be required to correctly parse and propagate markers (https://github.com/elastic/crd-ref-docs/pull/49).

```go
type Foo struct {
	A A `json:"a,omitempty"`
}

type A B
type B string
```