### PR TITLE
fix: handle fields' multi-line comments

### DIFF
--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -147,10 +147,13 @@ func (adr *AsciidoctorRenderer) RenderFieldDoc(text string) string {
 	// so that including | in a comment does not result in wonky tables.
 	out := strings.ReplaceAll(text, "|", "\\|")
 
-	// Replace newlines with spaces so that they don't break the asciidoc formatting.
+	// Trim any leading and trailing whitespace from each line.
 	lines := strings.Split(out, "\n")
 	for i := range lines {
 		lines[i] = strings.TrimSpace(lines[i])
 	}
-	return strings.Join(lines, " ")
+
+	// Replace newlines with hard line breaks so that newlines are rendered as expected.
+	// See: https://docs.asciidoctor.org/asciidoc/latest/blocks/hard-line-breaks
+	return strings.Join(lines, " +\n\n")
 }

--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -143,7 +143,14 @@ func (adr *AsciidoctorRenderer) RenderAnchorID(id string) string {
 }
 
 func (adr *AsciidoctorRenderer) RenderFieldDoc(text string) string {
-	// escape the pipe character, which has special meaning for asciidoc as a way to format tables,
-	// so that including | in a comment does not result in wonky tables
-	return strings.ReplaceAll(text, "|", "\\|")
+	// Escape the pipe character, which has special meaning for asciidoc as a way to format tables,
+	// so that including | in a comment does not result in wonky tables.
+	out := strings.ReplaceAll(text, "|", "\\|")
+
+	// Replace newlines with spaces so that they don't break the asciidoc formatting.
+	lines := strings.Split(out, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimSpace(lines[i])
+	}
+	return strings.Join(lines, " ")
 }

--- a/renderer/markdown.go
+++ b/renderer/markdown.go
@@ -78,6 +78,7 @@ func (m *MarkdownRenderer) ToFuncMap() template.FuncMap {
 		"SafeID":             m.SafeID,
 		"ShouldRenderType":   m.ShouldRenderType,
 		"TypeID":             m.TypeID,
+		"RenderFieldDoc":     m.RenderFieldDoc,
 	}
 }
 
@@ -139,4 +140,13 @@ func (m *MarkdownRenderer) RenderExternalLink(link, text string) string {
 
 func (m *MarkdownRenderer) RenderGVLink(gv types.GroupVersionDetails) string {
 	return m.RenderLocalLink(gv.GroupVersionString())
+}
+
+func (m *MarkdownRenderer) RenderFieldDoc(text string) string {
+	// Escape the pipe character, which has special meaning for Markdown as a way to format tables
+	// so that including | in a comment does not result in wonky tables.
+	out := strings.ReplaceAll(text, "|", "\\|")
+
+	// Replace newlines with 2 line breaks so that they don't break the Markdown table formatting.
+	return strings.ReplaceAll(out, "\n", "<br /><br />")
 }

--- a/templates/markdown/type_members.tpl
+++ b/templates/markdown/type_members.tpl
@@ -3,6 +3,6 @@
 {{- if eq $field.Name "metadata" -}}
 Refer to Kubernetes API documentation for fields of `metadata`.
 {{- else -}}
-{{ $field.Doc }}
+{{ markdownRenderFieldDoc $field.Doc }}
 {{- end -}}
 {{- end -}}

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -77,7 +77,9 @@ type GuestbookEntry struct {
 	Name string `json:"name,omitempty"`
 	// Time of entry
 	Time metav1.Time `json:"time,omitempty"`
-	// Comment by guest
+	// Comment by guest. This can be a multi-line comment.
+	//
+	// Just like this one.
 	Comment string `json:"comment,omitempty"`
 	// Rating provided by the guest
 	Rating Rating `json:"rating,omitempty"`

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -100,7 +100,7 @@ GuestbookEntry defines an entry in a guest book.
 | Field | Description
 | *`name`* __string__ | Name of the guest (pipe \| should be escaped)
 | *`time`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta[$$Time$$]__ | Time of entry
-| *`comment`* __string__ | Comment by guest
+| *`comment`* __string__ | Comment by guest. This can be a multi-line comment. Just like this one.
 | *`rating`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-rating[$$Rating$$]__ | Rating provided by the guest
 |===
 

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -100,7 +100,9 @@ GuestbookEntry defines an entry in a guest book.
 | Field | Description
 | *`name`* __string__ | Name of the guest (pipe \| should be escaped)
 | *`time`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta[$$Time$$]__ | Time of entry
-| *`comment`* __string__ | Comment by guest. This can be a multi-line comment. Just like this one.
+| *`comment`* __string__ | Comment by guest. This can be a multi-line comment. +
+
+Just like this one.
 | *`rating`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-rating[$$Rating$$]__ | Rating provided by the guest
 |===
 

--- a/test/expected.md
+++ b/test/expected.md
@@ -82,9 +82,9 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name of the guest (pipe | should be escaped) |
+| `name` _string_ | Name of the guest (pipe \| should be escaped) |
 | `time` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta)_ | Time of entry |
-| `comment` _string_ | Comment by guest |
+| `comment` _string_ | Comment by guest. This can be a multi-line comment. <br /><br /> Just like this one. |
 | `rating` _[Rating](#rating)_ | Rating provided by the guest |
 
 


### PR DESCRIPTION
If an API type field comment is multi-line, it breaks rendering both Markdown and Asiidoc tables. This PR aims to fix this issue by:
- turning newlines into two break lines (`<br />`) HTML elements in Markdown renderer, 
- turning newlines into hard break lines in Asiidoc renderer.

Should fix https://github.com/elastic/crd-ref-docs/issues/52.