### PR TITLE
fix: escape asterix in adoc

### DIFF
--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -164,14 +164,16 @@ func (adr *AsciidoctorRenderer) RenderValidation(text string) string {
 }
 
 func escapeEveryOtherAsterix(text string) string {
-	escape := true
+	index := -1
 	for i := 0; i < len(text); i++ {
 		if text[i] == '*' {
-			if escape {
-				text = text[:i] + "\\" + text[i:]
+			if index >= 0 {
+				text = text[:index] + "\\" + text[index:]
+				index = -1
 				i++
+			} else {
+				index = i
 			}
-			escape = !escape
 		}
 	}
 	return text

--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -160,10 +160,12 @@ func (adr *AsciidoctorRenderer) RenderFieldDoc(text string) string {
 }
 
 func (adr *AsciidoctorRenderer) RenderValidation(text string) string {
-	return escapeEveryOtherAsterix(text)
+	return escapeFirstAsterixInEachPair(text)
 }
 
-func escapeEveryOtherAsterix(text string) string {
+// escapeFirstAsterixInEachPair escapes the first asterix in each pair of
+// asterixes in text. E.g. "*a*b*c*" -> "\*a*b\*c*" and "*a*b*" -> "\*a*b*".
+func escapeFirstAsterixInEachPair(text string) string {
 	index := -1
 	for i := 0; i < len(text); i++ {
 		if text[i] == '*' {

--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -84,6 +84,7 @@ func (adr *AsciidoctorRenderer) ToFuncMap() template.FuncMap {
 		"ShouldRenderType":   adr.ShouldRenderType,
 		"TypeID":             adr.TypeID,
 		"RenderFieldDoc":     adr.RenderFieldDoc,
+		"RenderValidation":   adr.RenderValidation,
 	}
 }
 
@@ -156,4 +157,22 @@ func (adr *AsciidoctorRenderer) RenderFieldDoc(text string) string {
 	// Replace newlines with hard line breaks so that newlines are rendered as expected.
 	// See: https://docs.asciidoctor.org/asciidoc/latest/blocks/hard-line-breaks
 	return strings.Join(lines, " +\n\n")
+}
+
+func (adr *AsciidoctorRenderer) RenderValidation(text string) string {
+	return escapeEveryOtherAsterix(text)
+}
+
+func escapeEveryOtherAsterix(text string) string {
+	escape := true
+	for i := 0; i < len(text); i++ {
+		if text[i] == '*' {
+			if escape {
+				text = text[:i] + "\\" + text[i:]
+				i++
+			}
+			escape = !escape
+		}
+	}
+	return text
 }

--- a/renderer/asciidoctor_test.go
+++ b/renderer/asciidoctor_test.go
@@ -1,0 +1,15 @@
+package renderer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_escapeFirstAsterixInEachPair(t *testing.T) {
+	assert.Equal(t, "[a-z]", escapeFirstAsterixInEachPair("[a-z]"))
+	assert.Equal(t, "[a-z]*", escapeFirstAsterixInEachPair("[a-z]*"))
+	assert.Equal(t, `0\*[a-z]*`, escapeFirstAsterixInEachPair(`0*[a-z]*`))
+	assert.Equal(t, `0\*[a-z]*[a-z]*[0-9]`, escapeFirstAsterixInEachPair(`0*[a-z]*[a-z]*[0-9]`))
+	assert.Equal(t, `0\*[a-z]*[a-z]\*[0-9]*`, escapeFirstAsterixInEachPair(`0*[a-z]*[a-z]*[0-9]*`))
+}

--- a/renderer/markdown.go
+++ b/renderer/markdown.go
@@ -139,13 +139,6 @@ func (m *MarkdownRenderer) RenderExternalLink(link, text string) string {
 	return fmt.Sprintf("[%s](%s)", text, link)
 }
 
-func (m *MarkdownRenderer) RenderDefault(text string) string {
-	return strings.NewReplacer(
-		"{", "\\{",
-		"}", "\\}",
-	).Replace(text)
-}
-
 func (m *MarkdownRenderer) RenderGVLink(gv types.GroupVersionDetails) string {
 	return m.RenderLocalLink(gv.GroupVersionString())
 }
@@ -157,4 +150,11 @@ func (m *MarkdownRenderer) RenderFieldDoc(text string) string {
 
 	// Replace newlines with 2 line breaks so that they don't break the Markdown table formatting.
 	return strings.ReplaceAll(out, "\n", "<br /><br />")
+}
+
+func (m *MarkdownRenderer) RenderDefault(text string) string {
+	return strings.NewReplacer(
+		"{", "\\{",
+		"}", "\\}",
+	).Replace(text)
 }

--- a/templates/asciidoctor/type.tpl
+++ b/templates/asciidoctor/type.tpl
@@ -35,7 +35,7 @@
 {{ end -}}
 
 {{ range $type.Members -}}
-| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }} | {{ .Default }} | {{ range .Validation -}} {{ . }} +
+| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }} | {{ .Default }} | {{ range .Validation -}} {{ asciidocRenderValidation . }} +
 {{ end }}
 {{ end -}}
 |===

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -109,7 +109,7 @@ type GuestbookEntry struct {
 	// Comment by guest. This can be a multi-line comment.
 	//
 	// Just like this one.
-	// +kubebuilder:validation:Pattern=`[a-z0-9]`
+	// +kubebuilder:validation:Pattern=`0*[a-z0-9]*[a-z]*[0-9]*`
 	Comment string `json:"comment,omitempty"`
 	// Rating provided by the guest
 	Rating Rating `json:"rating,omitempty"`

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -103,6 +103,7 @@ type PositiveInt int
 type GuestbookEntry struct {
 	// Name of the guest (pipe | should be escaped)
 	// +kubebuilder:validation:MaxLength=80
+	// +kubebuilder:validation:Pattern=`0*[a-z0-9]*[a-z]*[0-9]`
 	Name string `json:"name,omitempty"`
 	// Time of entry
 	Time metav1.Time `json:"time,omitempty"`

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -120,7 +120,7 @@ GuestbookEntry defines an entry in a guest book.
 | *`time`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta[$$Time$$]__ | Time of entry |  | 
 | *`comment`* __string__ | Comment by guest. This can be a multi-line comment. +
 
-Just like this one. |  | Pattern: `[a-z0-9]` +
+Just like this one. |  | Pattern: `0\*[a-z0-9]*[a-z]\*[0-9]*` +
 
 | *`rating`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-rating[$$Rating$$]__ | Rating provided by the guest |  | Maximum: 5 +
 Minimum: 1 +

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -116,6 +116,7 @@ GuestbookEntry defines an entry in a guest book.
 |===
 | Field | Description | Default | Validation
 | *`name`* __string__ | Name of the guest (pipe \| should be escaped) |  | MaxLength: 80 +
+Pattern: `0\*[a-z0-9]*[a-z]*[0-9]` +
 
 | *`time`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta[$$Time$$]__ | Time of entry |  | 
 | *`comment`* __string__ | Comment by guest. This can be a multi-line comment. +

--- a/test/expected.md
+++ b/test/expected.md
@@ -91,7 +91,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `name` _string_ | Name of the guest (pipe \| should be escaped) |  | MaxLength: 80 <br /> |
+| `name` _string_ | Name of the guest (pipe \| should be escaped) |  | MaxLength: 80 <br />Pattern: `0*[a-z0-9]*[a-z]*[0-9]` <br /> |
 | `time` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta)_ | Time of entry |  |  |
 | `comment` _string_ | Comment by guest. This can be a multi-line comment. <br /><br /> Just like this one. |  | Pattern: `0*[a-z0-9]*[a-z]*[0-9]*` <br /> |
 | `rating` _[Rating](#rating)_ | Rating provided by the guest |  | Maximum: 5 <br />Minimum: 1 <br /> |

--- a/test/expected.md
+++ b/test/expected.md
@@ -93,7 +93,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _string_ | Name of the guest (pipe \| should be escaped) |  | MaxLength: 80 <br /> |
 | `time` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta)_ | Time of entry |  |  |
-| `comment` _string_ | Comment by guest. This can be a multi-line comment. <br /><br /> Just like this one. |  | Pattern: `[a-z0-9]` <br /> |
+| `comment` _string_ | Comment by guest. This can be a multi-line comment. <br /><br /> Just like this one. |  | Pattern: `0*[a-z0-9]*[a-z]*[0-9]*` <br /> |
 | `rating` _[Rating](#rating)_ | Rating provided by the guest |  | Maximum: 5 <br />Minimum: 1 <br /> |
 
 


### PR DESCRIPTION
Resolves https://github.com/elastic/crd-ref-docs/issues/61

Looks good in https://github.com/elastic/crd-ref-docs/blob/379dc3b3120b5b7cd8850cb89f99f85a458dfe09/test/expected.asciidoc#guestbookentry