### PR TITLE
chore: increase default max depth

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	cmd.Flags().StringVar(&args.TemplatesDir, "templates-dir", "", "Path to the directory containing template files")
 	cmd.Flags().StringVar(&args.Renderer, "renderer", "asciidoctor", "Renderer to use ('asciidoctor' or 'markdown')")
 	cmd.Flags().StringVar(&args.OutputPath, "output-path", ".", "Path to output the rendered result")
-	cmd.Flags().IntVar(&args.MaxDepth, "max-depth", 6, "Maximum recursion level for type discovery")
+	cmd.Flags().IntVar(&args.MaxDepth, "max-depth", 10, "Maximum recursion level for type discovery")
 
 	cmd.Execute()
 }


### PR DESCRIPTION
When migrating to `v0.0.10`, we had to bump our max depth.

I think https://github.com/elastic/crd-ref-docs/pull/51 introduced some new layers in parsing, and that the default depth should therefore be bumped a bit.