### PR TITLE
test: common api package

### DIFF
--- a/test/api/common/common.go
+++ b/test/api/common/common.go
@@ -1,0 +1,3 @@
+package common
+
+type CommonString string

--- a/test/api/common/groupversion_info.go
+++ b/test/api/common/groupversion_info.go
@@ -1,0 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package common contains common API Schema definitions
+// +groupName=webapp.test.k8s.elastic.co
+package common

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -18,6 +18,8 @@
 package v1
 
 import (
+	"github.com/elastic/crd-ref-docs/api/common"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -94,6 +96,7 @@ type GuestbookSpec struct {
 	Headers []GuestbookHeader `json:"headers,omitempty"`
 	// CertificateRef is a reference to a secret containing a certificate
 	CertificateRef gwapiv1b1.SecretObjectReference `json:"certificateRef"`
+	String         common.CommonString             `json:"str"`
 }
 
 // +kubebuilder:validation:Minimum=1
@@ -119,7 +122,8 @@ type GuestbookEntry struct {
 // GuestbookStatus defines the observed state of Guestbook.
 type GuestbookStatus struct {
 	// +kubebuilder:validation:Enum={OK, Error}
-	Status Status `json:"status"`
+	Status Status              `json:"status"`
+	String common.CommonString `json:"str"`
 }
 
 // +kubebuilder:validation:Enum={OK, Unknown, Error}

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -5,7 +5,33 @@
 == API Reference
 
 .Packages
+- xref:{anchor_prefix}-webapp-test-k8s-elastic-co-common[$$webapp.test.k8s.elastic.co/common$$]
 - xref:{anchor_prefix}-webapp-test-k8s-elastic-co-v1[$$webapp.test.k8s.elastic.co/v1$$]
+
+
+[id="{anchor_prefix}-webapp-test-k8s-elastic-co-common"]
+=== webapp.test.k8s.elastic.co/common
+
+Package common contains common API Schema definitions
+
+
+
+[id="{anchor_prefix}-github-com-elastic-crd-ref-docs-api-common-commonstring"]
+==== CommonString
+
+_Underlying type:_ _string_
+
+
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookspec[$$GuestbookSpec$$]
+- xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-guestbookstatus[$$GuestbookStatus$$]
+****
+
+
 
 
 [id="{anchor_prefix}-webapp-test-k8s-elastic-co-v1"]

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -192,6 +192,7 @@ GuestbookSpec defines the desired state of Guestbook.
 UniqueItems: true +
 
 | *`certificateRef`* __link:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.SecretObjectReference[$$SecretObjectReference$$]__ | CertificateRef is a reference to a secret containing a certificate |  | 
+| *`str`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-common-commonstring[$$CommonString$$]__ |  |  | 
 |===
 
 

--- a/test/expected.md
+++ b/test/expected.md
@@ -1,7 +1,29 @@
 # API Reference
 
 ## Packages
+- [webapp.test.k8s.elastic.co/common](#webapptestk8selasticcocommon)
 - [webapp.test.k8s.elastic.co/v1](#webapptestk8selasticcov1)
+
+
+## webapp.test.k8s.elastic.co/common
+
+Package common contains common API Schema definitions
+
+
+
+#### CommonString
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [GuestbookSpec](#guestbookspec)
+- [GuestbookStatus](#guestbookstatus)
+
+
 
 
 ## webapp.test.k8s.elastic.co/v1

--- a/test/expected.md
+++ b/test/expected.md
@@ -146,6 +146,7 @@ _Appears in:_
 | `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#labelselector-v1-meta)_ | Selector selects something |  |  |
 | `headers` _[GuestbookHeader](#guestbookheader) array_ | Headers contains a list of header items to include in the page |  | MaxItems: 10 <br />UniqueItems: true <br /> |
 | `certificateRef` _[SecretObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.SecretObjectReference)_ | CertificateRef is a reference to a secret containing a certificate |  |  |
+| `str` _[CommonString](#commonstring)_ |  |  |  |
 
 
 


### PR DESCRIPTION
The test should probably have multiple packages, to assert that references across packages are displayed correctly in doc.

Relates to https://github.com/elastic/crd-ref-docs/issues/58