### PR TITLE
fix: load external types from imports

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -210,6 +210,17 @@ func (p *processor) findAPITypes(directory string) error {
 				gvInfo.types[info.Name] = typeDef
 			}
 
+			// load imported types in fields
+			for _, importedType := range typeDef.Members() {
+				if importedType.Type != nil && importedType.Type.UnderlyingType != nil && importedType.Type.UnderlyingType.Imported {
+					key = fmt.Sprintf("%s.%s", importedType.Type.UnderlyingType.Package, importedType.Type.Name)
+					typeDef, ok = p.types[key]
+					if ok {
+						gvInfo.types[importedType.Name] = typeDef
+					}
+				}
+			}
+
 			// is this a root object?
 			if root := info.Markers.Get(objectRootMarker); root != nil {
 				if gvInfo.kinds == nil {


### PR DESCRIPTION
This PRs makes it possible to render imported types in a CRD.

For instance:

```go
package v1alpha1

import (
	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
	"github.com/starwars/jedi/pkg/weapons"
)

// +genclient
// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
// +kubebuilder:storageversion

// Jedi is a Jedi
type Jedi struct {
	metav1.TypeMeta `json:",inline"`
	// Standard object's metadata.
	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
	metav1.ObjectMeta `json:"metadata"`

	Spec JediSpec `json:"spec"`
}

// +k8s:deepcopy-gen=true

// JediSpec defines the desired state of a Jedi.
type JediSpec struct {
	Master *Jedi `json:"master,omitempty"`
	LightSaber *weapons.LightSaber `json:"lightSaber,omitempty"`
}
```

Without it, references are empty and https://github.com/elastic/crd-ref-docs/blob/master/renderer/markdown.go#L84 returns false.

Do you think this should be added as an opt-in or leaving it as default behavior is OK ?