### PR TITLE
Add version command

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	cmd.Flags().StringVar(&args.OutputPath, "output-path", ".", "Path to output the rendered result")
 	cmd.Flags().StringVar(&args.OutputMode, "output-mode", "single", "Output mode to generate a single file or one file per group ('group' or 'single')")
 	cmd.Flags().IntVar(&args.MaxDepth, "max-depth", 10, "Maximum recursion level for type discovery")
-
+	cmd.AddCommand(versionCmd)
 	cmd.Execute()
 }
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Run: func(cmd *cobra.Command, args []string) {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			fmt.Println("unknown")
+		} else {
+			fmt.Println(info.Main.Version)
+		}
+	},
+}


### PR DESCRIPTION
Hi old friends,

I beat my head against an issue for a while today, and it turned out because I had an older version of this CLI installed than my colleagues. We pin other dependencies but this one does not expose its version easily, so this adds a version command so we can easily ensure the desired version is installed. Hope you all are at least okay.

Anya

