### PR TITLE
Fix missing markdown table formatting

### DIFF
--- a/templates/markdown/type.tpl
+++ b/templates/markdown/type.tpl
@@ -38,6 +38,7 @@ _Appears in:_
 
 {{ if $type.EnumValues -}} 
 | Field | Description |
+| --- | --- |
 {{ range $type.EnumValues -}}
 | `{{ .Name }}` | {{ markdownRenderFieldDoc .Doc }} |
 {{ end -}}

--- a/test/expected.md
+++ b/test/expected.md
@@ -201,6 +201,7 @@ _Appears in:_
 - [GuestbookSpec](#guestbookspec)
 
 | Field | Description |
+| --- | --- |
 | `MyFirstValue` | MyFirstValue is an interesting value to use<br /> |
 | `MySecondValue` | MySecondValue is what you use when you can't use MyFirstValue<br /> |
 


### PR DESCRIPTION
Update the enum table in the `type.tpl` template to include missing table header, ensuring it renders correctly as a markdown table.