### PR TITLE
Return Exit Code 1 on Failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,11 +34,12 @@ var args = config.Flags{}
 
 func main() {
 	cmd := cobra.Command{
-		Use:          "crd-ref-docs",
-		Short:        "Generate CRD reference documentation",
-		SilenceUsage: true,
-		Version:      version(),
-		RunE:         doRun,
+		Use:           "crd-ref-docs",
+		Short:         "Generate CRD reference documentation",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Version:       version(),
+		RunE:          doRun,
 	}
 
 	cmd.SetVersionTemplate("{{ .Version }}\n")

--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ func main() {
 	cmd.Flags().StringVar(&args.OutputMode, "output-mode", "single", "Output mode to generate a single file or one file per group ('group' or 'single')")
 	cmd.Flags().IntVar(&args.MaxDepth, "max-depth", 10, "Maximum recursion level for type discovery")
 
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 func doRun(_ *cobra.Command, _ []string) error {


### PR DESCRIPTION
Previously, the code returned exit code 0 even when the template generation failed. Now, if an error occurs, the program will return exit code 1.

Additionally, silence errors from cobra execution. Previously, Cobra was printing non-formatted errors. However, we already log these errors via zap. This fix silences Cobra from printing redundant logs.
