### PR TITLE
Also support version on go install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
       - run: ./test.sh
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: '~> v1'
+          version: latest
           args: release --clean


### PR DESCRIPTION
This makes the `version` command also works when the binary is installed using `go install`.

Follow-up of #78 and #84.