### PR TITLE
feat: allow using custom markers on pkg level

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ render:
 
 #### Custom Markers
 
-You can add custom markers to your CRD types to provide additional information in the generated documentation. 
+You can add custom markers to your CRD types to provide additional information in the generated documentation.
 For example, you can add a `hidefromdoc` marker to indicate that a type is hide from the documentation.
 
 ```yaml
@@ -108,7 +108,9 @@ render:
      link: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.SecretObjectReference
 ```
 
-You can then add the `hidefromdoc` marker to the field you want to hidden from the documentation.
+You can then add the `hidefromdoc` marker to the field you want to hidden from the documentation. Markers can be added
+to fields, types and packages. The `target` field in the configuration specifies the target of the marker (it can be either
+`field`, `type` or `package`).
 
 ```go
 type Embedded1 struct {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -46,9 +46,10 @@ var ignoredCommentRegex = regexp.MustCompile(`\s*^(?i:\+|copyright)`)
 type groupVersionInfo struct {
 	schema.GroupVersion
 	*loader.Package
-	doc   string
-	kinds map[string]struct{}
-	types types.TypeMap
+	doc     string
+	kinds   map[string]struct{}
+	types   types.TypeMap
+	markers markers.MarkerValues
 }
 
 func Process(config *config.Config) ([]types.GroupVersionDetails, error) {
@@ -106,7 +107,7 @@ func Process(config *config.Config) ([]types.GroupVersionDetails, error) {
 				zap.S().Fatalw("Type not loaded", "type", key)
 			}
 		}
-
+		details.Markers = gvi.markers
 		gvDetails = append(gvDetails, details)
 	}
 
@@ -247,8 +248,9 @@ func (p *processor) extractGroupVersionIfExists(collector *markers.Collector, pk
 			Group:   groupName.(string),
 			Version: version,
 		},
-		doc:     p.extractPkgDocumentation(pkg),
 		Package: pkg,
+		doc:     p.extractPkgDocumentation(pkg),
+		markers: markerValues,
 	}
 
 	return gvInfo

--- a/test/api/common/groupversion_info.go
+++ b/test/api/common/groupversion_info.go
@@ -17,4 +17,5 @@
 
 // Package common contains common API Schema definitions
 // +groupName=webapp.test.k8s.elastic.co
+// +special
 package common

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -9,6 +9,8 @@ processor:
   customMarkers:
     - name: "hidefromdoc"
       target: field
+    - name: "special"
+      target: package
 
 render:
   kubernetesVersion: 1.25

--- a/test/hide.md
+++ b/test/hide.md
@@ -9,6 +9,7 @@
 
 Package common contains common API Schema definitions
 
+*Important: This package is special and should be treated differently.*
 
 
 #### CommonString

--- a/test/templates/markdown/gv_details.tpl
+++ b/test/templates/markdown/gv_details.tpl
@@ -5,6 +5,10 @@
 
 {{ $gv.Doc }}
 
+{{- if index $gv.Markers "special" }}
+*Important: This package is special and should be treated differently.*
+{{- end }}
+
 {{- if $gv.Kinds  }}
 ### Resource Types
 {{- range $gv.SortedKinds }}

--- a/types/types.go
+++ b/types/types.go
@@ -330,9 +330,10 @@ func Identifier(t *Type) string {
 // GroupVersionDetails encapsulates details about a discovered API group.
 type GroupVersionDetails struct {
 	schema.GroupVersion
-	Doc   string
-	Kinds []string
-	Types TypeMap
+	Doc     string
+	Kinds   []string
+	Types   TypeMap
+	Markers markers.MarkerValues
 }
 
 func (gvd GroupVersionDetails) GroupVersionString() string {


### PR DESCRIPTION
This starts propagating package-level markers so they can be used in templates if desired (similar to field and type-level markers).