### PR TITLE
change log level to warn when maxDepth exceed

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -298,7 +298,7 @@ func (p *processor) processType(pkg *loader.Package, parentType *types.Type, t g
 	}
 
 	if depth > p.maxDepth {
-		zap.S().Debugw("Not loading type due to reaching max recursion depth", "type", t.String())
+		zap.S().Warnw("Not loading type due to reaching max recursion depth", "type", t.String())
 		typeDef.Kind = types.UnknownKind
 		return typeDef
 	}


### PR DESCRIPTION
I spent the whole afternoon trying to figure out what the problem was, this's an important log, should live in warn level.