### PR TITLE
Fix markdown links to multi-version CRDs

### DIFF
--- a/renderer/markdown.go
+++ b/renderer/markdown.go
@@ -114,23 +114,14 @@ func (m *MarkdownRenderer) RenderTypeLink(t *types.Type) string {
 	}
 
 	if local {
-		return m.RenderLocalLink(text)
+		return m.RenderLocalLink(link, text)
 	} else {
 		return m.RenderExternalLink(link, text)
 	}
 }
 
-func (m *MarkdownRenderer) RenderLocalLink(text string) string {
-	anchor := strings.ToLower(
-		strings.NewReplacer(
-			" ", "-",
-			".", "",
-			"/", "",
-			"(", "",
-			")", "",
-		).Replace(text),
-	)
-	return fmt.Sprintf("[%s](#%s)", text, anchor)
+func (m *MarkdownRenderer) RenderLocalLink(link, text string) string {
+	return fmt.Sprintf("[%s](#%s)", text, link)
 }
 
 func (m *MarkdownRenderer) TemplateValue(key string) string {
@@ -145,7 +136,7 @@ func (m *MarkdownRenderer) RenderExternalLink(link, text string) string {
 }
 
 func (m *MarkdownRenderer) RenderGVLink(gv types.GroupVersionDetails) string {
-	return m.RenderLocalLink(gv.GroupVersionString())
+	return m.RenderLocalLink(m.GroupVersionID(gv), gv.GroupVersionString())
 }
 
 func (m *MarkdownRenderer) RenderFieldDoc(text string) string {

--- a/templates/markdown/gv_details.tpl
+++ b/templates/markdown/gv_details.tpl
@@ -1,7 +1,7 @@
 {{- define "gvDetails" -}}
 {{- $gv := . -}}
 
-## {{ $gv.GroupVersionString }}
+## <a id="{{ markdownGroupVersionID $gv | markdownSafeID }}">{{ $gv.GroupVersionString }}</a>
 
 {{ $gv.Doc }}
 

--- a/templates/markdown/type.tpl
+++ b/templates/markdown/type.tpl
@@ -2,7 +2,7 @@
 {{- $type := . -}}
 {{- if markdownShouldRenderType $type -}}
 
-#### {{ $type.Name }}
+#### <a id="{{ markdownTypeID $type | markdownSafeID }}">{{ $type.Name }}</a>
 
 {{ if $type.IsAlias }}_Underlying type:_ _{{ markdownRenderTypeLink $type.UnderlyingType  }}_{{ end }}
 
@@ -36,7 +36,7 @@ _Appears in:_
 
 {{ end -}}
 
-{{ if $type.EnumValues -}} 
+{{ if $type.EnumValues -}}
 | Field | Description |
 | --- | --- |
 {{ range $type.EnumValues -}}

--- a/test/expected.md
+++ b/test/expected.md
@@ -1,17 +1,17 @@
 # API Reference
 
 ## Packages
-- [webapp.test.k8s.elastic.co/common](#webapptestk8selasticcocommon)
-- [webapp.test.k8s.elastic.co/v1](#webapptestk8selasticcov1)
+- [webapp.test.k8s.elastic.co/common](#webapp-test-k8s-elastic-co-common)
+- [webapp.test.k8s.elastic.co/v1](#webapp-test-k8s-elastic-co-v1)
 
 
-## webapp.test.k8s.elastic.co/common
+## <a id="webapp-test-k8s-elastic-co-common">webapp.test.k8s.elastic.co/common</a>
 
 Package common contains common API Schema definitions
 
 
 
-#### CommonString
+#### <a id="github-com-elastic-crd-ref-docs-api-common-commonstring">CommonString</a>
 
 _Underlying type:_ _string_
 
@@ -20,25 +20,25 @@ _Underlying type:_ _string_
 
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
-- [GuestbookStatus](#guestbookstatus)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
+- [GuestbookStatus](#github-com-elastic-crd-ref-docs-api-v1-guestbookstatus)
 
 
 
 
-## webapp.test.k8s.elastic.co/v1
+## <a id="webapp-test-k8s-elastic-co-v1">webapp.test.k8s.elastic.co/v1</a>
 
 Package v1 contains API Schema definitions for the webapp v1 API group
 
 ### Resource Types
-- [Embedded](#embedded)
-- [Guestbook](#guestbook)
-- [GuestbookList](#guestbooklist)
-- [Underlying](#underlying)
+- [Embedded](#github-com-elastic-crd-ref-docs-api-v1-embedded)
+- [Guestbook](#github-com-elastic-crd-ref-docs-api-v1-guestbook)
+- [GuestbookList](#github-com-elastic-crd-ref-docs-api-v1-guestbooklist)
+- [Underlying](#github-com-elastic-crd-ref-docs-api-v1-underlying)
 
 
 
-#### Embedded
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-embedded">Embedded</a>
 
 
 
@@ -59,7 +59,7 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 | `value` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ |  |  |  |
 
 
-#### Embedded1
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-embedded1">Embedded1</a>
 
 
 
@@ -68,7 +68,7 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 
 
 _Appears in:_
-- [Embedded](#embedded)
+- [Embedded](#github-com-elastic-crd-ref-docs-api-v1-embedded)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -77,7 +77,7 @@ _Appears in:_
 | `value` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ |  |  |  |
 
 
-#### EmbeddedX
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-embeddedx">EmbeddedX</a>
 
 
 
@@ -86,8 +86,8 @@ _Appears in:_
 
 
 _Appears in:_
-- [Embedded](#embedded)
-- [Embedded1](#embedded1)
+- [Embedded](#github-com-elastic-crd-ref-docs-api-v1-embedded)
+- [Embedded1](#github-com-elastic-crd-ref-docs-api-v1-embedded1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -95,7 +95,7 @@ _Appears in:_
 | `value` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ |  |  |  |
 
 
-#### Guestbook
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbook">Guestbook</a>
 
 
 
@@ -104,17 +104,17 @@ Guestbook is the Schema for the guestbooks API.
 
 
 _Appears in:_
-- [GuestbookList](#guestbooklist)
+- [GuestbookList](#github-com-elastic-crd-ref-docs-api-v1-guestbooklist)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `apiVersion` _string_ | `webapp.test.k8s.elastic.co/v1` | | |
 | `kind` _string_ | `Guestbook` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[GuestbookSpec](#guestbookspec)_ |  | \{ page:1 \} |  |
+| `spec` _[GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)_ |  | \{ page:1 \} |  |
 
 
-#### GuestbookEntry
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbookentry">GuestbookEntry</a>
 
 
 
@@ -123,7 +123,7 @@ GuestbookEntry defines an entry in a guest book.
 
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -131,14 +131,14 @@ _Appears in:_
 | `tags` _string array_ | Tags of the entry. |  | items:Pattern: `[a-z]*` <br /> |
 | `time` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta)_ | Time of entry |  |  |
 | `comment` _string_ | Comment by guest. This can be a multi-line comment.<br />Like this one.<br />Now let's test a list:<br />* a<br />* b<br />Another isolated comment.<br />Looks good? |  | Pattern: `0*[a-z0-9]*[a-z]*[0-9]*\|\s` <br /> |
-| `rating` _[Rating](#rating)_ | Rating provided by the guest |  | Maximum: 5 <br />Minimum: 1 <br /> |
+| `rating` _[Rating](#github-com-elastic-crd-ref-docs-api-v1-rating)_ | Rating provided by the guest |  | Maximum: 5 <br />Minimum: 1 <br /> |
 | `email` _string_ | Email is the email address of the guest (required field using +required marker) |  | Required: \{\} <br /> |
 | `location` _string_ | Location is the location of the guest (required field using +k8s:required marker) |  | Required: \{\} <br /> |
 | `phone` _string_ | Phone is the phone number of the guest (optional field using +optional marker) |  | Optional: \{\} <br /> |
 | `company` _string_ | Company is the company of the guest (optional field using +k8s:optional marker) |  | Optional: \{\} <br /> |
 
 
-#### GuestbookHeader
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbookheader">GuestbookHeader</a>
 
 _Underlying type:_ _string_
 
@@ -147,11 +147,11 @@ GuestbookHeaders are strings to include at the top of a page.
 
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
 
 
 
-#### GuestbookList
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbooklist">GuestbookList</a>
 
 
 
@@ -166,10 +166,10 @@ GuestbookList contains a list of Guestbook.
 | `apiVersion` _string_ | `webapp.test.k8s.elastic.co/v1` | | |
 | `kind` _string_ | `GuestbookList` | | |
 | `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `items` _[Guestbook](#guestbook) array_ |  |  |  |
+| `items` _[Guestbook](#github-com-elastic-crd-ref-docs-api-v1-guestbook) array_ |  |  |  |
 
 
-#### GuestbookSpec
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbookspec">GuestbookSpec</a>
 
 
 
@@ -178,23 +178,23 @@ GuestbookSpec defines the desired state of Guestbook.
 
 
 _Appears in:_
-- [Guestbook](#guestbook)
+- [Guestbook](#github-com-elastic-crd-ref-docs-api-v1-guestbook)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `page` _[PositiveInt](#positiveint)_ | Page indicates the page number | 1 | Minimum: 1 <br /> |
-| `entries` _[GuestbookEntry](#guestbookentry) array_ | Entries contain guest book entries for the page |  |  |
+| `page` _[PositiveInt](#github-com-elastic-crd-ref-docs-api-v1-positiveint)_ | Page indicates the page number | 1 | Minimum: 1 <br /> |
+| `entries` _[GuestbookEntry](#github-com-elastic-crd-ref-docs-api-v1-guestbookentry) array_ | Entries contain guest book entries for the page |  |  |
 | `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#labelselector-v1-meta)_ | Selector selects something |  |  |
-| `headers` _[GuestbookHeader](#guestbookheader) array_ | Headers contains a list of header items to include in the page |  | MaxItems: 10 <br />UniqueItems: true <br /> |
+| `headers` _[GuestbookHeader](#github-com-elastic-crd-ref-docs-api-v1-guestbookheader) array_ | Headers contains a list of header items to include in the page |  | MaxItems: 10 <br />UniqueItems: true <br /> |
 | `certificateRef` _[SecretObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.SecretObjectReference)_ | CertificateRef is a reference to a secret containing a certificate |  |  |
-| `str` _[CommonString](#commonstring)_ |  |  |  |
-| `enum` _[MyEnum](#myenum)_ | Enumeration is an example of an aliased enumeration type |  | Enum: [MyFirstValue MySecondValue] <br /> |
+| `str` _[CommonString](#github-com-elastic-crd-ref-docs-api-common-commonstring)_ |  |  |  |
+| `enum` _[MyEnum](#github-com-elastic-crd-ref-docs-api-v1-myenum)_ | Enumeration is an example of an aliased enumeration type |  | Enum: [MyFirstValue MySecondValue] <br /> |
 | `digest` _string_ | Digest is the content-addressable identifier of the guestbook |  | Pattern: `^sha256:[a-fA-F0-9]\{64\}$` <br /> |
 
 
 
 
-#### MyEnum
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-myenum">MyEnum</a>
 
 _Underlying type:_ _string_
 
@@ -204,7 +204,7 @@ _Validation:_
 - Enum: [MyFirstValue MySecondValue]
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
 
 | Field | Description |
 | --- | --- |
@@ -212,7 +212,7 @@ _Appears in:_
 | `MySecondValue` | MySecondValue is what you use when you can't use MyFirstValue<br /> |
 
 
-#### PositiveInt
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-positiveint">PositiveInt</a>
 
 _Underlying type:_ _integer_
 
@@ -222,11 +222,11 @@ _Validation:_
 - Minimum: 1
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
 
 
 
-#### Rating
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-rating">Rating</a>
 
 _Underlying type:_ _integer_
 
@@ -237,13 +237,13 @@ _Validation:_
 - Minimum: 1
 
 _Appears in:_
-- [GuestbookEntry](#guestbookentry)
+- [GuestbookEntry](#github-com-elastic-crd-ref-docs-api-v1-guestbookentry)
 
 
 
 
 
-#### Underlying
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-underlying">Underlying</a>
 
 
 
@@ -258,12 +258,12 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 | `apiVersion` _string_ | `webapp.test.k8s.elastic.co/v1` | | |
 | `kind` _string_ | `Underlying` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `a` _[Underlying1](#underlying1)_ |  | b | MaxLength: 10 <br /> |
+| `a` _[Underlying1](#github-com-elastic-crd-ref-docs-api-v1-underlying1)_ |  | b | MaxLength: 10 <br /> |
 
 
-#### Underlying1
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-underlying1">Underlying1</a>
 
-_Underlying type:_ _[Underlying2](#underlying2)_
+_Underlying type:_ _[Underlying2](#github-com-elastic-crd-ref-docs-api-v1-underlying2)_
 
 Underlying1 has an underlying type with an underlying type
 
@@ -271,11 +271,11 @@ _Validation:_
 - MaxLength: 10
 
 _Appears in:_
-- [Underlying](#underlying)
+- [Underlying](#github-com-elastic-crd-ref-docs-api-v1-underlying)
 
 
 
-#### Underlying2
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-underlying2">Underlying2</a>
 
 _Underlying type:_ _string_
 
@@ -285,7 +285,7 @@ _Validation:_
 - MaxLength: 10
 
 _Appears in:_
-- [Underlying1](#underlying1)
+- [Underlying1](#github-com-elastic-crd-ref-docs-api-v1-underlying1)
 
 
 

--- a/test/hide.md
+++ b/test/hide.md
@@ -3,18 +3,18 @@
 Here is a template value: `v1`.
 
 ## Packages
-- [webapp.test.k8s.elastic.co/common](#webapptestk8selasticcocommon)
-- [webapp.test.k8s.elastic.co/v1](#webapptestk8selasticcov1)
+- [webapp.test.k8s.elastic.co/common](#webapp-test-k8s-elastic-co-common)
+- [webapp.test.k8s.elastic.co/v1](#webapp-test-k8s-elastic-co-v1)
 
 
-## webapp.test.k8s.elastic.co/common
+## <a id="webapp-test-k8s-elastic-co-common">webapp.test.k8s.elastic.co/common</a>
 
 Package common contains common API Schema definitions
 
 *Important: This package is special and should be treated differently.*
 
 
-#### CommonString
+#### <a id="github-com-elastic-crd-ref-docs-api-common-commonstring">CommonString</a>
 
 _Underlying type:_ _string_
 
@@ -23,25 +23,25 @@ _Underlying type:_ _string_
 
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
-- [GuestbookStatus](#guestbookstatus)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
+- [GuestbookStatus](#github-com-elastic-crd-ref-docs-api-v1-guestbookstatus)
 
 
 
 
-## webapp.test.k8s.elastic.co/v1
+## <a id="webapp-test-k8s-elastic-co-v1">webapp.test.k8s.elastic.co/v1</a>
 
 Package v1 contains API Schema definitions for the webapp v1 API group
 
 ### Resource Types
-- [Embedded](#embedded)
-- [Guestbook](#guestbook)
-- [GuestbookList](#guestbooklist)
-- [Underlying](#underlying)
+- [Embedded](#github-com-elastic-crd-ref-docs-api-v1-embedded)
+- [Guestbook](#github-com-elastic-crd-ref-docs-api-v1-guestbook)
+- [GuestbookList](#github-com-elastic-crd-ref-docs-api-v1-guestbooklist)
+- [Underlying](#github-com-elastic-crd-ref-docs-api-v1-underlying)
 
 
 
-#### Embedded
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-embedded">Embedded</a>
 
 
 
@@ -61,7 +61,7 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 | `value` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ |  |  |  |
 
 
-#### Embedded1
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-embedded1">Embedded1</a>
 
 
 
@@ -70,7 +70,7 @@ Package v1 contains API Schema definitions for the webapp v1 API group
 
 
 _Appears in:_
-- [Embedded](#embedded)
+- [Embedded](#github-com-elastic-crd-ref-docs-api-v1-embedded)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -78,7 +78,7 @@ _Appears in:_
 | `value` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ |  |  |  |
 
 
-#### EmbeddedX
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-embeddedx">EmbeddedX</a>
 
 
 
@@ -87,8 +87,8 @@ _Appears in:_
 
 
 _Appears in:_
-- [Embedded](#embedded)
-- [Embedded1](#embedded1)
+- [Embedded](#github-com-elastic-crd-ref-docs-api-v1-embedded)
+- [Embedded1](#github-com-elastic-crd-ref-docs-api-v1-embedded1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -96,7 +96,7 @@ _Appears in:_
 | `value` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ |  |  |  |
 
 
-#### Guestbook
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbook">Guestbook</a>
 
 
 
@@ -105,17 +105,17 @@ Guestbook is the Schema for the guestbooks API.
 
 
 _Appears in:_
-- [GuestbookList](#guestbooklist)
+- [GuestbookList](#github-com-elastic-crd-ref-docs-api-v1-guestbooklist)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `apiVersion` _string_ | `webapp.test.k8s.elastic.co/v1` | | |
 | `kind` _string_ | `Guestbook` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[GuestbookSpec](#guestbookspec)_ |  | \{ page:1 \} |  |
+| `spec` _[GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)_ |  | \{ page:1 \} |  |
 
 
-#### GuestbookEntry
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbookentry">GuestbookEntry</a>
 
 
 
@@ -124,7 +124,7 @@ GuestbookEntry defines an entry in a guest book.
 
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -132,14 +132,14 @@ _Appears in:_
 | `tags` _string array_ | Tags of the entry. |  | items:Pattern: `[a-z]*` <br /> |
 | `time` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta)_ | Time of entry |  |  |
 | `comment` _string_ | Comment by guest. This can be a multi-line comment.<br />Like this one.<br />Now let's test a list:<br />* a<br />* b<br />Another isolated comment.<br />Looks good? |  | Pattern: `0*[a-z0-9]*[a-z]*[0-9]*\|\s` <br /> |
-| `rating` _[Rating](#rating)_ | Rating provided by the guest |  | Maximum: 5 <br />Minimum: 1 <br /> |
+| `rating` _[Rating](#github-com-elastic-crd-ref-docs-api-v1-rating)_ | Rating provided by the guest |  | Maximum: 5 <br />Minimum: 1 <br /> |
 | `email` _string_ | Email is the email address of the guest (required field using +required marker) |  | Required: \{\} <br /> |
 | `location` _string_ | Location is the location of the guest (required field using +k8s:required marker) |  | Required: \{\} <br /> |
 | `phone` _string_ | Phone is the phone number of the guest (optional field using +optional marker) |  | Optional: \{\} <br /> |
 | `company` _string_ | Company is the company of the guest (optional field using +k8s:optional marker) |  | Optional: \{\} <br /> |
 
 
-#### GuestbookHeader
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbookheader">GuestbookHeader</a>
 
 _Underlying type:_ _string_
 
@@ -148,11 +148,11 @@ GuestbookHeaders are strings to include at the top of a page.
 
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
 
 
 
-#### GuestbookList
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbooklist">GuestbookList</a>
 
 
 
@@ -167,10 +167,10 @@ GuestbookList contains a list of Guestbook.
 | `apiVersion` _string_ | `webapp.test.k8s.elastic.co/v1` | | |
 | `kind` _string_ | `GuestbookList` | | |
 | `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `items` _[Guestbook](#guestbook) array_ |  |  |  |
+| `items` _[Guestbook](#github-com-elastic-crd-ref-docs-api-v1-guestbook) array_ |  |  |  |
 
 
-#### GuestbookSpec
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-guestbookspec">GuestbookSpec</a>
 
 
 
@@ -179,23 +179,23 @@ GuestbookSpec defines the desired state of Guestbook.
 
 
 _Appears in:_
-- [Guestbook](#guestbook)
+- [Guestbook](#github-com-elastic-crd-ref-docs-api-v1-guestbook)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `page` _[PositiveInt](#positiveint)_ | Page indicates the page number | 1 | Minimum: 1 <br /> |
-| `entries` _[GuestbookEntry](#guestbookentry) array_ | Entries contain guest book entries for the page |  |  |
+| `page` _[PositiveInt](#github-com-elastic-crd-ref-docs-api-v1-positiveint)_ | Page indicates the page number | 1 | Minimum: 1 <br /> |
+| `entries` _[GuestbookEntry](#github-com-elastic-crd-ref-docs-api-v1-guestbookentry) array_ | Entries contain guest book entries for the page |  |  |
 | `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#labelselector-v1-meta)_ | Selector selects something |  |  |
-| `headers` _[GuestbookHeader](#guestbookheader) array_ | Headers contains a list of header items to include in the page |  | MaxItems: 10 <br />UniqueItems: true <br /> |
+| `headers` _[GuestbookHeader](#github-com-elastic-crd-ref-docs-api-v1-guestbookheader) array_ | Headers contains a list of header items to include in the page |  | MaxItems: 10 <br />UniqueItems: true <br /> |
 | `certificateRef` _[SecretObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.SecretObjectReference)_ | CertificateRef is a reference to a secret containing a certificate |  |  |
-| `str` _[CommonString](#commonstring)_ |  |  |  |
-| `enum` _[MyEnum](#myenum)_ | Enumeration is an example of an aliased enumeration type |  | Enum: [MyFirstValue MySecondValue] <br /> |
+| `str` _[CommonString](#github-com-elastic-crd-ref-docs-api-common-commonstring)_ |  |  |  |
+| `enum` _[MyEnum](#github-com-elastic-crd-ref-docs-api-v1-myenum)_ | Enumeration is an example of an aliased enumeration type |  | Enum: [MyFirstValue MySecondValue] <br /> |
 | `digest` _string_ | Digest is the content-addressable identifier of the guestbook |  | Pattern: `^sha256:[a-fA-F0-9]\{64\}$` <br /> |
 
 
 
 
-#### MyEnum
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-myenum">MyEnum</a>
 
 _Underlying type:_ _string_
 
@@ -205,14 +205,14 @@ _Validation:_
 - Enum: [MyFirstValue MySecondValue]
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
 
 | Field | Description |
 | `MyFirstValue` | MyFirstValue is an interesting value to use<br /> |
 | `MySecondValue` | MySecondValue is what you use when you can't use MyFirstValue<br /> |
 
 
-#### PositiveInt
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-positiveint">PositiveInt</a>
 
 _Underlying type:_ _integer_
 
@@ -222,11 +222,11 @@ _Validation:_
 - Minimum: 1
 
 _Appears in:_
-- [GuestbookSpec](#guestbookspec)
+- [GuestbookSpec](#github-com-elastic-crd-ref-docs-api-v1-guestbookspec)
 
 
 
-#### Rating
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-rating">Rating</a>
 
 _Underlying type:_ _integer_
 
@@ -237,13 +237,13 @@ _Validation:_
 - Minimum: 1
 
 _Appears in:_
-- [GuestbookEntry](#guestbookentry)
+- [GuestbookEntry](#github-com-elastic-crd-ref-docs-api-v1-guestbookentry)
 
 
 
 
 
-#### Underlying
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-underlying">Underlying</a>
 
 
 
@@ -258,12 +258,12 @@ Underlying tests that Underlying1's underlying type is Underlying2 instead of st
 | `apiVersion` _string_ | `webapp.test.k8s.elastic.co/v1` | | |
 | `kind` _string_ | `Underlying` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `a` _[Underlying1](#underlying1)_ |  | b | MaxLength: 10 <br /> |
+| `a` _[Underlying1](#github-com-elastic-crd-ref-docs-api-v1-underlying1)_ |  | b | MaxLength: 10 <br /> |
 
 
-#### Underlying1
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-underlying1">Underlying1</a>
 
-_Underlying type:_ _[Underlying2](#underlying2)_
+_Underlying type:_ _[Underlying2](#github-com-elastic-crd-ref-docs-api-v1-underlying2)_
 
 Underlying1 has an underlying type with an underlying type
 
@@ -271,11 +271,11 @@ _Validation:_
 - MaxLength: 10
 
 _Appears in:_
-- [Underlying](#underlying)
+- [Underlying](#github-com-elastic-crd-ref-docs-api-v1-underlying)
 
 
 
-#### Underlying2
+#### <a id="github-com-elastic-crd-ref-docs-api-v1-underlying2">Underlying2</a>
 
 _Underlying type:_ _string_
 
@@ -285,7 +285,7 @@ _Validation:_
 - MaxLength: 10
 
 _Appears in:_
-- [Underlying1](#underlying1)
+- [Underlying1](#github-com-elastic-crd-ref-docs-api-v1-underlying1)
 
 
 

--- a/test/templates/markdown/gv_details.tpl
+++ b/test/templates/markdown/gv_details.tpl
@@ -1,7 +1,7 @@
 {{- define "gvDetails" -}}
 {{- $gv := . -}}
 
-## {{ $gv.GroupVersionString }}
+## <a id="{{ markdownGroupVersionID $gv | markdownSafeID }}">{{ $gv.GroupVersionString }}</a>
 
 {{ $gv.Doc }}
 

--- a/test/templates/markdown/type.tpl
+++ b/test/templates/markdown/type.tpl
@@ -2,7 +2,7 @@
 {{- $type := . -}}
 {{- if markdownShouldRenderType $type -}}
 
-#### {{ $type.Name }}
+#### <a id="{{ markdownTypeID $type | markdownSafeID }}">{{ $type.Name }}</a>
 
 {{ if $type.IsAlias }}_Underlying type:_ _{{ markdownRenderTypeLink $type.UnderlyingType  }}_{{ end }}
 


### PR DESCRIPTION
## Implementation
This PR fixes links to multi-version CRDs by adding a reference to the version in the anchor and the link.

## Approach
I considered implementing links in pure Markdown, like `#### v1.Embedded1`, but preferred to use HTML links instead, like `#### <a id="github-com-elastic-crd-ref-docs-api-v1-embedded1">Embedded1</a>`. This approach is closer to what is done in Asciidoc and the final result seems more readable to me (especially in multigroup APIs where it would look like `#### mygroupname-v2alpha1.Embedded1`). I guess supporting both methods could be an option, but it would require two functions to render links, and users would need to know how to adjust their templating accordingly.

This change will also break existing links in custom Markdown templates, as it now uses GroupVersionID to link to resources. To fix this, replace `## {{ $gv.GroupVersionString }}` in gv_details.tpl with `## <a id="{{ markdownGroupVersionID $gv | markdownSafeID }}">{{ $gv.GroupVersionString }}</a>`. 

As explained in #60 I could not find a way to implement this change in a backward-compatible manner for users having custom markdown templating, except by introducing a new function like `markdownRenderHTMLTypeLink`. However, I wanted to get feedback before implementing this approach because:
* the current rendering method is broken for multiversion APIs
* crd-ref-docs is still in v0.x.y so I think we could tolerate breaking custom templates for markdown
* this change would align Markdown output more closely with AsciiDoc

Fixes #60