### PR TITLE
Escape curly braces in validation text for `asciidoc`

### DIFF
--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -160,7 +160,8 @@ func (adr *AsciidoctorRenderer) RenderFieldDoc(text string) string {
 }
 
 func (adr *AsciidoctorRenderer) RenderValidation(text string) string {
-	return escapeFirstAsterixInEachPair(text)
+	renderedText := escapeFirstAsterixInEachPair(text)
+	return escapeCurlyBraces(renderedText)
 }
 
 // escapeFirstAsterixInEachPair escapes the first asterix in each pair of
@@ -179,4 +180,11 @@ func escapeFirstAsterixInEachPair(text string) string {
 		}
 	}
 	return text
+}
+
+// escapeCurlyBraces ensures sufficient escapes are added to curly braces, so they are not mistaken
+// for asciidoctor id attributes.
+func escapeCurlyBraces(text string) string {
+	// Per asciidoctor docs, only the leading curly brace needs to be escaped.
+	return strings.Replace(text, "{", "\\{", -1)
 }

--- a/renderer/asciidoctor_test.go
+++ b/renderer/asciidoctor_test.go
@@ -13,3 +13,9 @@ func Test_escapeFirstAsterixInEachPair(t *testing.T) {
 	assert.Equal(t, `0\*[a-z]*[a-z]*[0-9]`, escapeFirstAsterixInEachPair(`0*[a-z]*[a-z]*[0-9]`))
 	assert.Equal(t, `0\*[a-z]*[a-z]\*[0-9]*`, escapeFirstAsterixInEachPair(`0*[a-z]*[a-z]*[0-9]*`))
 }
+
+func Test_escapeCurlyBraces(t *testing.T) {
+	assert.Equal(t, "[a-z]", escapeCurlyBraces("[a-z]"))
+	assert.Equal(t, "[a-fA-F0-9]\\{64}", escapeCurlyBraces("[a-fA-F0-9]{64}"))
+	assert.Equal(t, "[a-fA-F0-9]\\\\{64\\}", escapeCurlyBraces("[a-fA-F0-9]\\{64\\}"))
+}

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -103,6 +103,9 @@ type GuestbookSpec struct {
 	String         common.CommonString             `json:"str"`
 	// Enumeration is an example of an aliased enumeration type
 	Enumeration MyEnum `json:"enum"`
+	// Digest is the content-addressable identifier of the guestbook
+	// +kubebuilder:validation:Pattern=`^sha256:[a-fA-F0-9]{64}$`
+	Digest string `json:"digest,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=MyFirstValue;MySecondValue

--- a/test/expected.asciidoc
+++ b/test/expected.asciidoc
@@ -246,6 +246,8 @@ UniqueItems: true +
 | *`str`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-common-commonstring[$$CommonString$$]__ |  |  | 
 | *`enum`* __xref:{anchor_prefix}-github-com-elastic-crd-ref-docs-api-v1-myenum[$$MyEnum$$]__ | Enumeration is an example of an aliased enumeration type + |  | Enum: [MyFirstValue MySecondValue] +
 
+| *`digest`* __string__ | Digest is the content-addressable identifier of the guestbook + |  | Pattern: `^sha256:[a-fA-F0-9]\{64}$` +
+
 |===
 
 

--- a/test/expected.md
+++ b/test/expected.md
@@ -184,6 +184,7 @@ _Appears in:_
 | `certificateRef` _[SecretObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.SecretObjectReference)_ | CertificateRef is a reference to a secret containing a certificate |  |  |
 | `str` _[CommonString](#commonstring)_ |  |  |  |
 | `enum` _[MyEnum](#myenum)_ | Enumeration is an example of an aliased enumeration type |  | Enum: [MyFirstValue MySecondValue] <br /> |
+| `digest` _string_ | Digest is the content-addressable identifier of the guestbook |  | Pattern: `^sha256:[a-fA-F0-9]\{64\}$` <br /> |
 
 
 

--- a/test/hide.md
+++ b/test/hide.md
@@ -183,6 +183,7 @@ _Appears in:_
 | `certificateRef` _[SecretObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.SecretObjectReference)_ | CertificateRef is a reference to a secret containing a certificate |  |  |
 | `str` _[CommonString](#commonstring)_ |  |  |  |
 | `enum` _[MyEnum](#myenum)_ | Enumeration is an example of an aliased enumeration type |  | Enum: [MyFirstValue MySecondValue] <br /> |
+| `digest` _string_ | Digest is the content-addressable identifier of the guestbook |  | Pattern: `^sha256:[a-fA-F0-9]\{64\}$` <br /> |
 
 
 


### PR DESCRIPTION
Asciidoc interprets curly braces as an identifier. Kubebuilder validations may contain curly braces as part of a regular expression pattern. This adds an escape character to the leading curly brace when rendering validation content for `asciidoctor`. Per documentation [1], this is sufficient to prevent id attribute interpretation.

This change does not broadly add escape characters to all curly braces used in CRD godoc text. This risks breaking teams that have embedded asciidoc within their code comments - for example, to provide links or other cross-references.

Fixes #137

[1] https://docs.asciidoctor.org/asciidoc/latest/subs/prevent/#escape-with-backslashes