### PR TITLE
Disable CGO in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
       - windows
       - darwin
     ldflags: -s -w -X main.buildVersion={{.Tag}} -X main.buildCommit={{.ShortCommit}} -X main.buildDate={{.Date}}
+    env:
+      - CGO_ENABLED=0
 archives:
   - name_template: >-
       {{- .ProjectName }}_


### PR DESCRIPTION
Released binaries for `linux/amd64` are dynamically linked, which makes them difficult to use in Alpine. Since we don't need to use anything related to CGO, we can simply disable it and it resolves the issue as it then produces a static build for native platforms. (Tested under `linux/arm64`, but the principle is the same.)

```
root@3b09588545ab:/app# ./bin/usr/bin/goreleaser build --auto-snapshot --clean
  • git repository is dirty and --auto-snapshot is set, implying --snapshot
(...)
  • building binaries
(...)
    • building                                       binary=dist/crd-ref-docs_linux_arm64_v8.0/crd-ref-docs
    • building                                       binary=dist/crd-ref-docs_linux_amd64_v1/crd-ref-docs
  • writing artifacts metadata
  • build succeeded after 2s
  • thanks for using GoReleaser!
root@3b09588545ab:/app# file dist/crd-ref-docs_linux_arm64_v8.0/crd-ref-docs
dist/crd-ref-docs_linux_arm64_v8.0/crd-ref-docs: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=cc463edfc52943e7e51371d5bd79bda8ad72c591, stripped
root@3b09588545ab:/app# ./bin/usr/bin/goreleaser build --auto-snapshot --clean
  • git repository is dirty and --auto-snapshot is set, implying --snapshot
(...)
  • building binaries
(...)
    • building                                       binary=dist/crd-ref-docs_linux_arm64_v8.0/crd-ref-docs
    • building                                       binary=dist/crd-ref-docs_linux_amd64_v1/crd-ref-docs
  • writing artifacts metadata
  • build succeeded after 1s
  • thanks for using GoReleaser!
root@3b09588545ab:/app# file dist/crd-ref-docs_linux_arm64_v8.0/crd-ref-docs
dist/crd-ref-docs_linux_arm64_v8.0/crd-ref-docs: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=4a3dd349969936b41fe9b603d14fee9ad9765703, stripped
```


(See the `dynamically/statically linked` outputted from `file` before/after. The first build being from fresh `master`, the second build using the code in this PR.)

Resolves: #151