### PR TITLE
Allow additional template variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 out.asciidoc
 out.md
+
+# editor and IDE paraphernalia
 .idea
+.vscode
+*.swp
+*.sw
+*.iml
+*~
+*.DS_Store

--- a/config/config.go
+++ b/config/config.go
@@ -68,14 +68,15 @@ const (
 )
 
 type Flags struct {
-	Config       string
-	LogLevel     string
-	OutputPath   string
-	Renderer     string
-	SourcePath   string
-	TemplatesDir string
-	OutputMode   string
-	MaxDepth     int
+	Config            string
+	LogLevel          string
+	OutputPath        string
+	Renderer          string
+	SourcePath        string
+	TemplatesDir      string
+	OutputMode        string
+	MaxDepth          int
+	TemplateKeyValues KeyValueFlags
 }
 
 func Load(flags Flags) (*Config, error) {

--- a/config/kv.go
+++ b/config/kv.go
@@ -1,0 +1,69 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+type KeyValue struct {
+	Key   string
+	Value string
+}
+type KeyValueFlags []KeyValue
+
+// KeyValue is an implementation of the flag.Value interface
+func (kvs *KeyValueFlags) String() string {
+	return fmt.Sprintf("%v", *kvs)
+}
+
+// Type implements pflag.Value
+func (kvs *KeyValueFlags) Type() string {
+	return "duration"
+}
+
+func (kvs *KeyValueFlags) AsMap() map[string]string {
+	if kvs == nil {
+		return nil
+	}
+	m := make(map[string]string, len(*kvs))
+	for _, kv := range *kvs {
+		m[kv.Key] = kv.Value
+	}
+	return m
+}
+
+// Set is an implementation of the flag.Value interface
+func (kvs *KeyValueFlags) Set(value string) error {
+	if value == "" {
+		return nil
+	}
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid key-value pair: %s, expected format key=value", value)
+	}
+	key := strings.TrimSpace(parts[0])
+	value = strings.TrimSpace(parts[1])
+	if key == "" || value == "" {
+		return fmt.Errorf("key and value must not be empty: %s", value)
+	}
+	kv := KeyValue{Key: key, Value: value}
+	*kvs = append(*kvs, kv)
+	return nil
+}

--- a/config/kv.go
+++ b/config/kv.go
@@ -35,7 +35,7 @@ func (kvs *KeyValueFlags) String() string {
 
 // Type implements pflag.Value
 func (kvs *KeyValueFlags) Type() string {
-	return "duration"
+	return "key value"
 }
 
 func (kvs *KeyValueFlags) AsMap() map[string]string {

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 	cmd.Flags().StringVar(&args.OutputPath, "output-path", ".", "Path to output the rendered result")
 	cmd.Flags().StringVar(&args.OutputMode, "output-mode", "single", "Output mode to generate a single file or one file per group ('group' or 'single')")
 	cmd.Flags().IntVar(&args.MaxDepth, "max-depth", 10, "Maximum recursion level for type discovery")
+	cmd.Flags().Var(&args.TemplateKeyValues, "template-value", "Can be used in template to pass in a version number or similar information. Example: --template-value=key1=value1 and {{ markdownTemplateValue \"k1\" }}")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/renderer/asciidoctor.go
+++ b/renderer/asciidoctor.go
@@ -82,6 +82,7 @@ func (adr *AsciidoctorRenderer) ToFuncMap() template.FuncMap {
 		"TypeID":             adr.TypeID,
 		"RenderFieldDoc":     adr.RenderFieldDoc,
 		"RenderValidation":   adr.RenderValidation,
+		"TemplateValue":      adr.TemplateValue,
 	}
 }
 
@@ -138,6 +139,13 @@ func (adr *AsciidoctorRenderer) RenderGVLink(gv types.GroupVersionDetails) strin
 
 func (adr *AsciidoctorRenderer) RenderAnchorID(id string) string {
 	return fmt.Sprintf("%s%s", asciidocAnchorPrefix, adr.SafeID(id))
+}
+
+func (adr *AsciidoctorRenderer) TemplateValue(key string) string {
+	if adr == nil || adr.conf == nil {
+		return ""
+	}
+	return adr.conf.TemplateKeyValues.AsMap()[key]
 }
 
 func (adr *AsciidoctorRenderer) RenderFieldDoc(text string) string {

--- a/renderer/markdown.go
+++ b/renderer/markdown.go
@@ -77,6 +77,7 @@ func (m *MarkdownRenderer) ToFuncMap() template.FuncMap {
 		"TypeID":             m.TypeID,
 		"RenderFieldDoc":     m.RenderFieldDoc,
 		"RenderDefault":      m.RenderDefault,
+		"TemplateValue":      m.TemplateValue,
 	}
 }
 
@@ -130,6 +131,13 @@ func (m *MarkdownRenderer) RenderLocalLink(text string) string {
 		).Replace(text),
 	)
 	return fmt.Sprintf("[%s](#%s)", text, anchor)
+}
+
+func (m *MarkdownRenderer) TemplateValue(key string) string {
+	if m == nil || m.conf == nil {
+		return ""
+	}
+	return m.conf.TemplateKeyValues.AsMap()[key]
 }
 
 func (m *MarkdownRenderer) RenderExternalLink(link, text string) string {

--- a/renderer/markdown_test.go
+++ b/renderer/markdown_test.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package renderer
+
+import (
+	"testing"
+
+	"github.com/elastic/crd-ref-docs/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	conf := &config.Config{}
+	if err := conf.TemplateKeyValues.Set("foo=bar"); err != nil {
+		t.Fatal(err)
+	}
+	if err := conf.TemplateKeyValues.Set("hello=world"); err != nil {
+		t.Fatal(err)
+	}
+	return conf
+}
+
+func TestMarkdownRenderer_TemplateValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		renderer *MarkdownRenderer
+		key      string
+		want     string
+	}{
+		{
+			name:     "existing key",
+			renderer: &MarkdownRenderer{conf: newTestConfig(t)},
+			key:      "foo",
+			want:     "bar",
+		},
+		{
+			name:     "another existing key",
+			renderer: &MarkdownRenderer{conf: newTestConfig(t)},
+			key:      "hello",
+			want:     "world",
+		},
+		{
+			name:     "missing key",
+			renderer: &MarkdownRenderer{conf: newTestConfig(t)},
+			key:      "missing",
+			want:     "",
+		},
+		{
+			name:     "nil config",
+			renderer: &MarkdownRenderer{conf: nil},
+			key:      "foo",
+			want:     "",
+		},
+		{
+			name:     "nil renderer",
+			renderer: nil,
+			key:      "foo",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.renderer.TemplateValue(tt.key))
+		})
+	}
+}

--- a/test.sh
+++ b/test.sh
@@ -83,7 +83,7 @@ run_test() {
         cmd=(go run main.go "${args[@]}")
         echo "${cmd[@]}"
 
-        "${cmd[@]}"
+        "${cmd[@]}"  --template-value=k1=v1
 
         local diff
         if diff=$(diff -a -y --suppress-common-lines "${SCRIPT_DIR}/test/${expected}" "$actual"); then

--- a/test/hide.md
+++ b/test/hide.md
@@ -1,5 +1,7 @@
 # API Reference
 
+Here is a template value: `v1`.
+
 ## Packages
 - [webapp.test.k8s.elastic.co/common](#webapptestk8selasticcocommon)
 - [webapp.test.k8s.elastic.co/v1](#webapptestk8selasticcov1)

--- a/test/templates/markdown/gv_list.tpl
+++ b/test/templates/markdown/gv_list.tpl
@@ -3,6 +3,8 @@
 
 # API Reference
 
+Here is a template value: `{{ markdownTemplateValue "k1" }}`.
+
 ## Packages
 {{- range $groupVersions }}
 - {{ markdownRenderGVLink . }}


### PR DESCRIPTION
Similar to https://github.com/elastic/go-licence-detector/pull/29:

```
./crd-ref-docs --template-value=k1=v1
```

```md
# My API Reference
Here is a value: {{ markdownTemplateValue "k1" }}
```

So I think I'm going to do the same in https://github.com/elastic/go-licence-detector/pull/29 for consistency.