### PR TITLE
fix: support both types of default marker

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -554,16 +554,18 @@ func parseMarkers(markers markers.MarkerValues) (string, []string) {
 			validation = append(validation, fmt.Sprintf("%s: %v", name, value))
 		}
 
-		if name == "kubebuilder:default" {
-			if value, ok := value.(crdmarkers.Default); ok {
-				defaultValue = fmt.Sprintf("%v", value.Value)
-				if strings.HasPrefix(defaultValue, "map[") {
-					defaultValue = strings.TrimPrefix(defaultValue, "map[")
-					defaultValue = strings.TrimSuffix(defaultValue, "]")
-					defaultValue = fmt.Sprintf("{ %s }", defaultValue)
-				}
-			}
+		switch v := value.(type) {
+		case crdmarkers.KubernetesDefault:
+			defaultValue = fmt.Sprintf("%v", v.Value)
+		case crdmarkers.Default:
+			defaultValue = fmt.Sprintf("%v", v.Value)
 		}
+	}
+
+	if strings.HasPrefix(defaultValue, "map[") {
+		defaultValue = strings.TrimPrefix(defaultValue, "map[")
+		defaultValue = strings.TrimSuffix(defaultValue, "]")
+		defaultValue = fmt.Sprintf("{ %s }", defaultValue)
 	}
 
 	return defaultValue, validation

--- a/test/api/v1/guestbook_types.go
+++ b/test/api/v1/guestbook_types.go
@@ -87,7 +87,7 @@ type Rating int
 // +kubebuilder:validation:XValidation:rule="self.page < 200", message="Please start a new book."
 type GuestbookSpec struct {
 	// Page indicates the page number
-	// +kubebuilder:default=1
+	// +default=1
 	// +kubebuilder:example=3
 	Page *PositiveInt `json:"page,omitempty"`
 	// Entries contain guest book entries for the page


### PR DESCRIPTION
As the two are listed here, I think we should allow both of them: https://github.com/kubernetes-sigs/controller-tools/blob/ce150814f15374641a8c53b5a05eb29845948ffa/pkg/crd/markers/validation.go#L104-L107