### PR TITLE
support custom markers with values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,8 +39,9 @@ type ProcessorConfig struct {
 }
 
 type Marker struct {
-	Name   string
-	Target TargetType
+	Name     string
+	Target   TargetType
+	HasValue bool `json:"hasValue"`
 }
 
 type TargetType string

--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,9 @@ type ProcessorConfig struct {
 }
 
 type Marker struct {
-	Name   string
-	Target TargetType
+	Name     string
+	Target   TargetType
+	HasValue bool `json:"hasValue"`
 }
 
 type TargetType string

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -536,8 +536,18 @@ func mkRegistry(customMarkers []config.Marker) (*markers.Registry, error) {
 			continue
 		}
 
-		if err := registry.Define(marker.Name, t, struct{}{}); err != nil {
+		var d *markers.Definition
+		var err error
+		if marker.HasValue {
+			d, err = markers.MakeAnyTypeDefinition(marker.Name, t, crdmarkers.Default{})
+		} else {
+			d, err = markers.MakeDefinition(marker.Name, t, struct{}{})
+		}
+		if err != nil {
 			return nil, fmt.Errorf("failed to define custom marker %s: %w", marker.Name, err)
+		}
+		if err := registry.Register(d); err != nil {
+			return nil, fmt.Errorf("failed to register custom marker %s: %w", marker.Name, err)
 		}
 	}
 
@@ -556,7 +566,6 @@ func parseMarkers(markers markers.MarkerValues) (string, []string) {
 
 	for _, name := range markerNames {
 		value := markers[name][len(markers[name])-1]
-
 		if strings.HasPrefix(name, "kubebuilder:validation:") {
 			name := strings.TrimPrefix(name, "kubebuilder:validation:")
 


### PR DESCRIPTION
currently only custom markers without values are supported, this PR adds ability to use `hasValue` parameter to treat given custom marker as marker with value
related issue https://github.com/elastic/crd-ref-docs/issues/124