### PR TITLE
Ignore knownTypes for local types

### DIFF
--- a/renderer/functions.go
+++ b/renderer/functions.go
@@ -75,11 +75,10 @@ func (f *Functions) LinkForType(t *types.Type) (link string, local bool) {
 		return f.LinkForKubeType(t), false
 	}
 
-	if kt, ok := f.IsKnownType(t); ok {
-		return f.LinkForKnownType(kt), false
-	}
-
 	if t.IsBasic() || t.Imported {
+		if kt, ok := f.IsKnownType(t); ok {
+			return f.LinkForKnownType(kt), false
+		}
 		return "", false
 	}
 

--- a/renderer/functions_test.go
+++ b/renderer/functions_test.go
@@ -24,6 +24,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLinkForType(t *testing.T) {
+	conf := config.Config{
+		Render: config.RenderConfig{
+			KubernetesVersion: "1.29",
+			KnownTypes: []*config.KnownType{
+				// Register our own package to verify it is ignored for local types.
+				{Name: "Foo", Package: "example.com/pkg", Link: "https://example.com/docs#foo"},
+				// Also register a kube type to verify IsKubeType takes precedence over knownTypes.
+				{Name: "ObjectMeta", Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Link: "https://example.com/docs#objectmeta"},
+			},
+		},
+	}
+
+	f, err := NewFunctions(&conf)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name      string
+		typ       *types.Type
+		wantLink  string
+		wantLocal bool
+	}{
+		{
+			name:      "imported type gets external link from knownTypes",
+			typ:       &types.Type{Name: "Foo", Package: "example.com/pkg", Imported: true},
+			wantLink:  "https://example.com/docs#foo",
+			wantLocal: false,
+		},
+		{
+			name:      "local type ignores knownTypes and gets local link",
+			typ:       &types.Type{Name: "Foo", Package: "example.com/pkg", Imported: false},
+			// FIXME: This is incorrect and should be a relative link
+			// wantLink:  "example-com-pkg-foo",
+			// wantLocal: true,
+			wantLink:  "https://example.com/docs#foo",
+			wantLocal: false,
+		},
+		{
+			name:      "kube type gets kubernetes.io link even when also in knownTypes",
+			typ:       &types.Type{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ObjectMeta"},
+			wantLink:  "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectmeta-v1-meta",
+			wantLocal: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			link, local := f.LinkForType(tc.typ)
+			require.Equal(t, tc.wantLink, link)
+			require.Equal(t, tc.wantLocal, local)
+		})
+	}
+}
+
 func TestKubernetesHelper(t *testing.T) {
 	conf := config.Config{
 		Render: config.RenderConfig{

--- a/renderer/functions_test.go
+++ b/renderer/functions_test.go
@@ -55,11 +55,8 @@ func TestLinkForType(t *testing.T) {
 		{
 			name:      "local type ignores knownTypes and gets local link",
 			typ:       &types.Type{Name: "Foo", Package: "example.com/pkg", Imported: false},
-			// FIXME: This is incorrect and should be a relative link
-			// wantLink:  "example-com-pkg-foo",
-			// wantLocal: true,
-			wantLink:  "https://example.com/docs#foo",
-			wantLocal: false,
+			wantLink:  "example-com-pkg-foo",
+			wantLocal: true,
 		},
 		{
 			name:      "kube type gets kubernetes.io link even when also in knownTypes",


### PR DESCRIPTION
`knownTypes` entries were being applied to all types regardless of whether they were local to the source package or imported from another package. This caused local types that appeared in `knownTypes` to be rendered with external links rather than local anchor links, breaking in-page navigation when rendered locally.

Move the `knownTypes` lookup inside the `IsBasic`/`Imported` branch so that it only applies to types that cannot resolve to a local anchor.

This was spotted while attempting to migrate https://github.com/kubernetes-sigs/cluster-api-provider-openstack from https://github.com/ahmetb/gen-crd-api-reference-docs to this project.
