### PR TITLE
Support field aliases from json case:ignore tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,20 @@ type Embedded1 struct {
 ```
 
 Then update the templates to render the custom markers. You can find an example [here](./test/templates/markdown/type.tpl).
+
+#### Field Aliases
+
+For fields carrying the `encoding/json/v2` `case:ignore` tag option, the documentation can
+list alternative names alongside the canonical one. Set `processor.caseIgnoreAliases` to the
+conventions to derive (`camelCase` and/or `snake_case`); when empty (the default) no aliases
+are shown.
+
+```yaml
+processor:
+ caseIgnoreAliases:
+   - camelCase
+   - snake_case
+```
+
+For a field tagged `json:"groupWait,case:ignore"`, the documentation displays `groupWait`
+together with the derived `group_wait` alias.

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,17 @@ type Config struct {
 	Flags     `json:"-"`
 }
 
+// NamingConvention identifies a field-naming style to derive as an alias
+// when a struct field carries the json `case:ignore` tag option.
+type NamingConvention string
+
+const (
+	// NamingConventionCamelCase derives the lowerCamelCase form (e.g. "groupWait" for "group_wait").
+	NamingConventionCamelCase NamingConvention = "camelCase"
+	// NamingConventionSnakeCase derives the snake_case form (e.g. "group_wait" for "groupWait").
+	NamingConventionSnakeCase NamingConvention = "snake_case"
+)
+
 type ProcessorConfig struct {
 	MaxDepth            int      `json:"maxDepth"`
 	IgnoreTypes         []string `json:"ignoreTypes"`
@@ -36,6 +47,10 @@ type ProcessorConfig struct {
 	IgnoreGroupVersions []string `json:"ignoreGroupVersions"`
 	UseRawDocstring     bool     `json:"useRawDocstring"`
 	CustomMarkers       []Marker `json:"customMarkers"`
+	// CaseIgnoreAliases lists the naming conventions to derive and display as
+	// alternative field names whenever a struct field carries the json `case:ignore`
+	// tag option. When empty, no aliases are shown for such fields.
+	CaseIgnoreAliases []NamingConvention `json:"caseIgnoreAliases"`
 }
 
 type Marker struct {

--- a/processor/aliases_test.go
+++ b/processor/aliases_test.go
@@ -1,0 +1,118 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/elastic/crd-ref-docs/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasCaseIgnore(t *testing.T) {
+	testCases := []struct {
+		name    string
+		options []string
+		want    bool
+	}{
+		{name: "empty", options: nil, want: false},
+		{name: "name only", options: []string{"groupWait"}, want: false},
+		{name: "case ignore", options: []string{"groupWait", "case:ignore"}, want: true},
+		{name: "case ignore with spaces", options: []string{"groupWait", " case:ignore "}, want: true},
+		{name: "case ignore among options", options: []string{"groupWait", "omitempty", "case:ignore"}, want: true},
+		{name: "case strict", options: []string{"groupWait", "case:strict"}, want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, hasCaseIgnore(tc.options))
+		})
+	}
+}
+
+func TestToSnakeCase(t *testing.T) {
+	testCases := []struct {
+		in   string
+		want string
+	}{
+		{in: "groupWait", want: "group_wait"},
+		{in: "apiURL", want: "api_url"},
+		{in: "URLApi", want: "url_api"},
+		{in: "group_wait", want: "group_wait"},
+		{in: "HTTPSProxy", want: "https_proxy"},
+		{in: "GroupWait", want: "group_wait"},
+		{in: "v1Beta", want: "v1_beta"},
+		{in: "enabled", want: "enabled"},
+		{in: "x", want: "x"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.in, func(t *testing.T) {
+			require.Equal(t, tc.want, toSnakeCase(tc.in))
+		})
+	}
+}
+
+func TestToCamelCase(t *testing.T) {
+	testCases := []struct {
+		in   string
+		want string
+	}{
+		{in: "group_wait", want: "groupWait"},
+		{in: "api_url", want: "apiUrl"},
+		{in: "groupWait", want: "groupWait"},
+		{in: "enabled", want: "enabled"},
+		{in: "x", want: "x"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.in, func(t *testing.T) {
+			require.Equal(t, tc.want, toCamelCase(tc.in))
+		})
+	}
+}
+
+func TestDeriveAliases(t *testing.T) {
+	testCases := []struct {
+		name          string
+		conventions   []config.NamingConvention
+		canonicalName string
+		want          []string
+	}{
+		{
+			name:          "no conventions",
+			conventions:   nil,
+			canonicalName: "groupWait",
+			want:          nil,
+		},
+		{
+			name:          "snake alias for camel field",
+			conventions:   []config.NamingConvention{config.NamingConventionSnakeCase},
+			canonicalName: "groupWait",
+			want:          []string{"group_wait"},
+		},
+		{
+			name:          "camel alias for snake field",
+			conventions:   []config.NamingConvention{config.NamingConventionCamelCase},
+			canonicalName: "group_wait",
+			want:          []string{"groupWait"},
+		},
+		{
+			name:          "identical derivation omitted",
+			conventions:   []config.NamingConvention{config.NamingConventionCamelCase, config.NamingConventionSnakeCase},
+			canonicalName: "groupWait",
+			want:          []string{"group_wait"},
+		},
+		{
+			name:          "single word yields no aliases",
+			conventions:   []config.NamingConvention{config.NamingConventionCamelCase, config.NamingConventionSnakeCase},
+			canonicalName: "enabled",
+			want:          nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &processor{compiledConfig: &compiledConfig{caseIgnoreAliases: tc.conventions}}
+			require.Equal(t, tc.want, p.deriveAliases(tc.canonicalName))
+		})
+	}
+}

--- a/processor/config.go
+++ b/processor/config.go
@@ -34,6 +34,7 @@ func compileConfig(conf *config.Config) (cc *compiledConfig, err error) {
 		ignoreGroupVersions: make([]*regexp.Regexp, len(conf.Processor.IgnoreGroupVersions)),
 		useRawDocstring:     conf.Processor.UseRawDocstring,
 		markers:             conf.Processor.CustomMarkers,
+		caseIgnoreAliases:   conf.Processor.CaseIgnoreAliases,
 	}
 
 	for i, t := range conf.Processor.IgnoreTypes {
@@ -63,6 +64,7 @@ type compiledConfig struct {
 	ignoreGroupVersions []*regexp.Regexp
 	useRawDocstring     bool
 	markers             []config.Marker
+	caseIgnoreAliases   []config.NamingConvention
 }
 
 func (cc *compiledConfig) shouldIgnoreGroupVersion(gv string) bool {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -674,7 +674,7 @@ func (p *processor) deriveAliases(canonicalName string) []string {
 }
 
 // toSnakeCase converts a camelCase or PascalCase string to snake_case.
-// e.g. "groupWait" -> "group_wait", "apiURL" -> "api_url"
+// e.g. "groupWait" -> "group_wait", "apiURL" -> "api_url", "v1Beta" -> "v1_beta"
 func toSnakeCase(s string) string {
 	runes := []rune(s)
 	var b strings.Builder
@@ -685,7 +685,7 @@ func toSnakeCase(s string) string {
 		}
 		if unicode.IsUpper(r) {
 			prev := runes[i-1]
-			if unicode.IsLower(prev) || (unicode.IsUpper(prev) && i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+			if unicode.IsLower(prev) || unicode.IsDigit(prev) || (unicode.IsUpper(prev) && i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
 				b.WriteByte('_')
 			}
 			b.WriteRune(unicode.ToLower(r))

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -415,10 +415,6 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 			}
 		}
 
-		if hasCaseIgnore(f.Tag.Get("json")) {
-			fieldDef.Aliases = p.deriveAliases(fieldDef.Name)
-		}
-
 		t := pkg.TypesInfo.TypeOf(f.RawField.Type)
 		if t == nil {
 			zap.S().Debugw("Failed to determine type of field", "field", fieldDef.Name)
@@ -436,6 +432,12 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 
 		if fieldDef.Name == "" {
 			fieldDef.Name = fieldDef.Type.Name
+		}
+
+		// Derive aliases once the field name has been fully resolved, so they
+		// are based on the displayed name rather than an intermediate value.
+		if hasCaseIgnore(f.Tag.Get("json")) {
+			fieldDef.Aliases = p.deriveAliases(fieldDef.Name)
 		}
 
 		if p.shouldIgnoreField(parentTypeKey, fieldDef.Name) {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -405,6 +405,7 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 			Embedded: f.Name == "",
 		}
 
+		var caseIgnore bool
 		if tagVal, ok := f.Tag.Lookup("json"); ok {
 			args := strings.Split(tagVal, ",")
 			if len(args) > 0 && args[0] != "" {
@@ -413,6 +414,7 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 			if len(args) > 1 && args[1] == "inline" {
 				fieldDef.Inlined = true
 			}
+			caseIgnore = hasCaseIgnore(args)
 		}
 
 		t := pkg.TypesInfo.TypeOf(f.RawField.Type)
@@ -436,7 +438,7 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 
 		// Derive aliases once the field name has been fully resolved, so they
 		// are based on the displayed name rather than an intermediate value.
-		if hasCaseIgnore(f.Tag.Get("json")) {
+		if caseIgnore {
 			fieldDef.Aliases = p.deriveAliases(fieldDef.Name)
 		}
 
@@ -640,9 +642,10 @@ func lookupConstantValuesForAliasedType(pkg *loader.Package, aliasTypeName strin
 	return values
 }
 
-// hasCaseIgnore reports whether a json struct tag contains the "case:ignore" option.
-func hasCaseIgnore(tag string) bool {
-	for _, part := range strings.Split(tag, ",") {
+// hasCaseIgnore reports whether the comma-separated json struct tag options
+// contain the "case:ignore" option.
+func hasCaseIgnore(options []string) bool {
+	for _, part := range options {
 		if strings.TrimSpace(part) == "case:ignore" {
 			return true
 		}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/elastic/crd-ref-docs/config"
 	"github.com/elastic/crd-ref-docs/types"
@@ -414,6 +415,10 @@ func (p *processor) processStructFields(parentType *types.Type, pkg *loader.Pack
 			}
 		}
 
+		if hasCaseIgnore(f.Tag.Get("json")) {
+			fieldDef.Aliases = p.deriveAliases(fieldDef.Name)
+		}
+
 		t := pkg.TypesInfo.TypeOf(f.RawField.Type)
 		if t == nil {
 			zap.S().Debugw("Failed to determine type of field", "field", fieldDef.Name)
@@ -569,7 +574,7 @@ func parseMarkers(markers markers.MarkerValues) (string, []string) {
 			defaultValue = fmt.Sprintf("%v", v.Value)
 		}
 
-    // Handle standalone +required and +k8s:required marker
+		// Handle standalone +required and +k8s:required marker
 		// This is equivalent to +kubebuilder:validation:Required
 		if name == "required" || name == "k8s:required" {
 			validation = append(validation, "Required: {}")
@@ -631,4 +636,76 @@ func lookupConstantValuesForAliasedType(pkg *loader.Package, aliasTypeName strin
 		}
 	}
 	return values
+}
+
+// hasCaseIgnore reports whether a json struct tag contains the "case:ignore" option.
+func hasCaseIgnore(tag string) bool {
+	for _, part := range strings.Split(tag, ",") {
+		if strings.TrimSpace(part) == "case:ignore" {
+			return true
+		}
+	}
+	return false
+}
+
+// deriveAliases returns alternative names for canonicalName based on the
+// configured caseIgnoreAliases conventions. Names identical to canonicalName
+// are omitted.
+func (p *processor) deriveAliases(canonicalName string) []string {
+	var aliases []string
+	for _, conv := range p.caseIgnoreAliases {
+		var derived string
+		switch conv {
+		case config.NamingConventionCamelCase:
+			derived = toCamelCase(canonicalName)
+		case config.NamingConventionSnakeCase:
+			derived = toSnakeCase(canonicalName)
+		}
+		if derived != "" && derived != canonicalName {
+			aliases = append(aliases, derived)
+		}
+	}
+	return aliases
+}
+
+// toSnakeCase converts a camelCase or PascalCase string to snake_case.
+// e.g. "groupWait" -> "group_wait", "apiURL" -> "api_url"
+func toSnakeCase(s string) string {
+	runes := []rune(s)
+	var b strings.Builder
+	for i, r := range runes {
+		if i == 0 {
+			b.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		if unicode.IsUpper(r) {
+			prev := runes[i-1]
+			if unicode.IsLower(prev) || (unicode.IsUpper(prev) && i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+				b.WriteByte('_')
+			}
+			b.WriteRune(unicode.ToLower(r))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// toCamelCase converts a snake_case string to lowerCamelCase.
+// e.g. "group_wait" -> "groupWait"
+func toCamelCase(s string) string {
+	parts := strings.Split(s, "_")
+	if len(parts) == 1 {
+		return s
+	}
+	var b strings.Builder
+	for i, p := range parts {
+		if i == 0 || len(p) == 0 {
+			b.WriteString(p)
+		} else {
+			b.WriteRune(unicode.ToUpper(rune(p[0])))
+			b.WriteString(p[1:])
+		}
+	}
+	return b.String()
 }

--- a/templates/asciidoctor/type.tpl
+++ b/templates/asciidoctor/type.tpl
@@ -35,7 +35,7 @@
 {{ end -}}
 
 {{ range $type.Members -}}
-| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }} | {{ .Default }} | {{ range .Validation -}} {{ asciidocRenderValidation . }} +
+| *`{{ .Name }}`*{{ if .Aliases }} _(or {{ range $i, $a := .Aliases }}{{ if $i }}, {{ end }}`{{ $a }}`{{ end }})_{{ end }} __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }} | {{ .Default }} | {{ range .Validation -}} {{ asciidocRenderValidation . }} +
 {{ end }}
 {{ end -}}
 |===

--- a/templates/markdown/type.tpl
+++ b/templates/markdown/type.tpl
@@ -31,7 +31,7 @@ _Appears in:_
 {{ end -}}
 
 {{ range $type.Members -}}
-| `{{ .Name  }}` _{{ markdownRenderType .Type }}_ | {{ template "type_members" . }} | {{ markdownRenderDefault .Default }} | {{ range .Validation -}} {{ markdownRenderFieldDoc . }} <br />{{ end }} |
+| `{{ .Name }}`{{ if .Aliases }}<br/>_(or {{ range $i, $a := .Aliases }}{{ if $i }}, {{ end }}`{{ $a }}`{{ end }})_{{ end }} _{{ markdownRenderType .Type }}_ | {{ template "type_members" . }} | {{ markdownRenderDefault .Default }} | {{ range .Validation -}} {{ markdownRenderFieldDoc . }} <br />{{ end }} |
 {{ end -}}
 
 {{ end -}}

--- a/types/types.go
+++ b/types/types.go
@@ -284,8 +284,9 @@ func (t *Type) propagateMarkers() {
 // Field describes a field in a struct.
 type Field struct {
 	Name       string
-	Embedded   bool // Embedded struct in Go typing
-	Inlined    bool // Inlined struct in serialization
+	Aliases    []string // alternative JSON key names from the "aliases" struct tag
+	Embedded   bool     // Embedded struct in Go typing
+	Inlined    bool     // Inlined struct in serialization
 	Doc        string
 	Default    string
 	Validation []string

--- a/types/types.go
+++ b/types/types.go
@@ -284,7 +284,7 @@ func (t *Type) propagateMarkers() {
 // Field describes a field in a struct.
 type Field struct {
 	Name       string
-	Aliases    []string // alternative JSON key names from the "aliases" struct tag
+	Aliases    []string // alternative names derived from the json "case:ignore" tag option
 	Embedded   bool     // Embedded struct in Go typing
 	Inlined    bool     // Inlined struct in serialization
 	Doc        string


### PR DESCRIPTION
## Summary

`encoding/json/v2` supports the `case:ignore` JSON tag option, which lets a
field be matched against alternative naming conventions (e.g. snake_case /
camelCase). This PR surfaces those alternative names so they can be documented:

- Fields tagged with json `case:ignore` now expose their alternative names via
  `Field.Aliases`, available in templates (markdown & asciidoctor).
- A new `processor.caseIgnoreAliases` option controls which naming conventions
  are generated for aliases.

## Details

Alias derivation reuses the JSON tag options already parsed for the field name
and runs after the field name is fully resolved, so aliases match the displayed
name. Snake-casing inserts a word boundary before an uppercase letter that
follows a digit (`v1Beta` → `v1_beta`).

## Changes

- Add `Field.Aliases` and populate it from the json `case:ignore` tag option
- Add the `processor.caseIgnoreAliases` config option (documented in the README)
- Render aliases in the markdown and asciidoctor type templates
- Unit tests covering `hasCaseIgnore`, `toSnakeCase`, `toCamelCase` and
  `deriveAliases`, including acronym, digit-boundary and identical-derivation
  edge cases
